### PR TITLE
feat: sprint 4 e 5 — laudos, dashboard por perfil e CRUD de clientes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 > **Tech Lead:** Gabriel Azevedo | **Dev:** Sabrina  
 > **Stack:** React 19 + TypeScript + MUI v7 + React Hook Form + Zod + Axios  
 > **API:** Django REST Framework + JWT (SimpleJWT) — `http://localhost:8000/api/`  
-> **Última atualização:** 03/04/2026
+> **Última atualização:** 06/04/2026
 
 ---
 
@@ -181,6 +181,7 @@ Regras de ouro:
 6. Sempre exibir loading
 7. Campos calculados sao somente leitura
 8. `n_lab` segue `AAAA/NNN`
+9. **MUI Grid:** usar sempre `import { Grid } from "@mui/material"` com `<Grid container>` e `<Grid size={{ xs, md }}>` (Grid v2). Nunca usar `@mui/material/Grid2` ou `@mui/material/Unstable_Grid2` — modulos inexistentes neste projeto.
 
 ### Regra de Terminal e Comandos (Mãos no Teclado)
 
@@ -284,11 +285,23 @@ Em seguida, garanta que a palavra `node_modules/` está escrita dentro do seu ar
 
 ### Gabriel — `feat/gabriel/foundation`
 
-- Sprint 0: setup, tema, tipos, base de API e auth
-- Sprint 1: login, register, layout, rotas, shared
-- Sprint 2: calibracao completa
-- Sprint 3: Operacao em Lote (rota /entrada-lote, UI profissional)
-- Sprint 4: formulario de criacao de laudo
+- ✅ Sprint 0: setup, tema, tipos, base de API e auth
+- ✅ Sprint 1: login, register, layout, rotas, shared
+- ✅ Sprint 2: calibracao completa
+- ✅ Sprint 3: Operacao em Lote (rota /entrada-lote, UI profissional)
+- ✅ Sprint 4: formulario de criacao de laudo + dashboard por perfil (staff/cliente)
+  - `src/services/laudoService.ts` — CRUD + PDF (lidar, criar, buscar, atualizar, remover, baixarPdf, listarMeusLaudos, baixarPdfLaudo)
+  - `src/hooks/useLaudoForm.ts` — hook de criacao com Zod + react-hook-form
+  - `src/hooks/useLaudos.ts` — listagem + download de PDF para cliente
+  - `src/schemas/laudoSchemas.ts` — schema Zod com input/output types
+  - `src/pages/laudos/LaudoFormPage.tsx` — formulario de criacao (rota /laudos/novo, staff only)
+  - `src/pages/dashboard/DashboardPlaceholder.tsx` — staff ve cards, cliente ve ClientDashboard
+  - `src/pages/dashboard/components/ClientDashboard.tsx` — area do cliente com laudos recentes e PDF
+- 🔲 Sprint 5: CRUD de clientes (staff only)
+  - **Backend:** serializer `ClienteCadastroSerializer` + views `ClienteListCreateView` / `ClienteDetailView` + rotas `/clientes/` e `/clientes/<codigo>/`
+  - **Frontend — Bloco 1:** atualizar `src/types/cliente.ts` + `src/services/clienteService.ts` (adicionar criar, atualizar, remover)
+  - **Frontend — Bloco 2:** `src/schemas/clienteSchemas.ts` (Zod) + `src/hooks/useClientes.ts` (listagem) + `src/hooks/useClienteForm.ts` (criacao/edicao)
+  - **Frontend — Bloco 3:** `src/pages/clientes/ClientesPage.tsx` (tabela MUI com acoes) + `src/pages/clientes/ClienteFormPage.tsx` (formulario criar/editar) + rota `/clientes` (staff only) + link na sidebar
 
 ### Sabrina — `feat/sabrina/laudos`
 
@@ -297,7 +310,7 @@ Em seguida, garanta que a palavra `node_modules/` está escrita dentro do seu ar
 
 Zonas sem conflito:
 
-- Gabriel: theme, types, api, auth, contexts, layout, shared, calibracao, operacao-lote
+- Gabriel: theme, types, api, auth, contexts, layout, shared, calibracao, operacao-lote, clientes
 - Sabrina: laudos, dashboard, laudoService, hooks de laudo
 
 ---

--- a/backend/src/infrastructure/web/serializers.py
+++ b/backend/src/infrastructure/web/serializers.py
@@ -80,6 +80,26 @@ class ClienteSerializer(serializers.ModelSerializer):
         fields = ["codigo", "nome", "municipio", "area"]
 
 
+class ClienteCadastroSerializer(serializers.ModelSerializer):
+    """
+    CRUD de clientes pelo staff.
+    Nao cria conta de usuario — apenas dados cadastrais.
+    O campo `codigo` e imutavel apos a criacao (read_only no update).
+    """
+
+    class Meta:
+        model = Cliente
+        fields = ["codigo", "nome", "contato", "municipio", "area", "observacoes"]
+
+    def validate_codigo(self, value):
+        # Na atualizacao (instance ja existe), ignora a validacao de unicidade
+        if self.instance and self.instance.codigo == value:
+            return value
+        if Cliente.objects.filter(codigo=value).exists():
+            raise serializers.ValidationError("Ja existe um cliente com este codigo.")
+        return value
+
+
 # Serializer principal para os resultados das analises quimicas
 class AnaliseSoloSerializer(serializers.ModelSerializer):
     """

--- a/backend/src/infrastructure/web/urls.py
+++ b/backend/src/infrastructure/web/urls.py
@@ -62,4 +62,17 @@ urlpatterns = [
         views.LeituraEquipamentoCreateView.as_view(),
         name="leitura_create",
     ),
+    # ---------------------------------------------------------
+    # 5 GESTAO DE CLIENTES (staff only)
+    # ---------------------------------------------------------
+    path(
+        "clientes/",
+        views.ClienteListCreateView.as_view(),
+        name="clientes_list_create",
+    ),
+    path(
+        "clientes/<str:codigo>/",
+        views.ClienteDetailView.as_view(),
+        name="cliente_detail",
+    ),
 ]

--- a/backend/src/infrastructure/web/views.py
+++ b/backend/src/infrastructure/web/views.py
@@ -17,11 +17,13 @@ from weasyprint import HTML
 from src.infrastructure.database.models import (
     AnaliseSolo,
     BateriaCalibracao,
+    Cliente,
     LeituraEquipamento,
     PontoCalibracao,
 )
 from .serializers import (
     AnaliseSoloSerializer,
+    ClienteCadastroSerializer,
     UserRegistrationSerializer,
     BateriaCalibracaoSerializer,
     BateriaCalibracaoAtivoSerializer,
@@ -370,3 +372,48 @@ class LeituraEquipamentoCreateView(generics.CreateAPIView):
 
         headers = self.get_success_headers(serializer.data)
         return Response(data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+# =============================================================================
+# 6 GESTAO DE CLIENTES (staff only)
+# =============================================================================
+
+
+class ClienteListCreateView(generics.ListCreateAPIView):
+    """
+    GET  /api/clientes/          -> Lista todos os clientes (suporte a ?search=)
+    POST /api/clientes/          -> Cria um novo cliente (somente dados cadastrais)
+    Somente staff tem acesso.
+    """
+
+    serializer_class = ClienteCadastroSerializer
+
+    def get_permissions(self):
+        from rest_framework.permissions import IsAdminUser
+
+        return [IsAuthenticated(), IsAdminUser()]
+
+    def get_queryset(self):
+        qs = Cliente.objects.all().order_by("nome")
+        search = self.request.query_params.get("search")
+        if search:
+            qs = qs.filter(nome__icontains=search) | qs.filter(codigo__icontains=search)
+        return qs
+
+
+class ClienteDetailView(generics.RetrieveUpdateDestroyAPIView):
+    """
+    GET    /api/clientes/<codigo>/  -> Detalhe do cliente
+    PATCH  /api/clientes/<codigo>/  -> Atualiza dados cadastrais
+    DELETE /api/clientes/<codigo>/  -> Remove cliente
+    Somente staff tem acesso.
+    """
+
+    serializer_class = ClienteCadastroSerializer
+    queryset = Cliente.objects.all()
+    lookup_field = "codigo"
+
+    def get_permissions(self):
+        from rest_framework.permissions import IsAdminUser
+
+        return [IsAuthenticated(), IsAdminUser()]

--- a/labas-web/src/App.tsx
+++ b/labas-web/src/App.tsx
@@ -19,6 +19,9 @@ const CalibracaoFormPage = lazy(
 const EntradaLotePage = lazy(
   () => import("./pages/operacao-lote/EntradaLotePage"),
 );
+const LaudoFormPage = lazy(() => import("./pages/laudos/LaudoFormPage"));
+const ClientesPage = lazy(() => import("./pages/clientes/ClientesPage"));
+const ClienteFormPage = lazy(() => import("./pages/clientes/ClienteFormPage"));
 
 const Spinner = () => (
   <Box display="flex" justifyContent="center" py={8}>
@@ -83,6 +86,46 @@ export default function App() {
             <AppShell>
               <Suspense fallback={<Spinner />}>
                 <EntradaLotePage />
+              </Suspense>
+            </AppShell>
+          }
+        />
+        <Route
+          path="/laudos/novo"
+          element={
+            <AppShell>
+              <Suspense fallback={<Spinner />}>
+                <LaudoFormPage />
+              </Suspense>
+            </AppShell>
+          }
+        />
+        <Route
+          path="/clientes"
+          element={
+            <AppShell>
+              <Suspense fallback={<Spinner />}>
+                <ClientesPage />
+              </Suspense>
+            </AppShell>
+          }
+        />
+        <Route
+          path="/clientes/novo"
+          element={
+            <AppShell>
+              <Suspense fallback={<Spinner />}>
+                <ClienteFormPage />
+              </Suspense>
+            </AppShell>
+          }
+        />
+        <Route
+          path="/clientes/:codigo/editar"
+          element={
+            <AppShell>
+              <Suspense fallback={<Spinner />}>
+                <ClienteFormPage />
               </Suspense>
             </AppShell>
           }

--- a/labas-web/src/components/layout/AppSidebar.tsx
+++ b/labas-web/src/components/layout/AppSidebar.tsx
@@ -11,6 +11,7 @@ import Typography from "@mui/material/Typography";
 import DashboardIcon from "@mui/icons-material/Dashboard";
 import ScienceIcon from "@mui/icons-material/Science";
 import AssignmentIcon from "@mui/icons-material/Assignment";
+import PeopleIcon from "@mui/icons-material/People";
 import { NavLink } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
 
@@ -27,6 +28,7 @@ const navComum = [
 /** Itens de navegação exclusivos de staff */
 const navStaff = [
   { label: "Calibração", icon: <ScienceIcon />, to: "/calibracao" },
+  { label: "Clientes", icon: <PeopleIcon />, to: "/clientes" },
 ];
 
 /**

--- a/labas-web/src/hooks/useClienteForm.ts
+++ b/labas-web/src/hooks/useClienteForm.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { clienteService } from "../services/clienteService";
+import { clienteSchema } from "../schemas/clienteSchemas";
+import { useSnackbar } from "./useSnackbar";
+import type {
+  ClienteSchemaInput,
+  ClienteSchemaOutput,
+} from "../schemas/clienteSchemas";
+import type { Cliente } from "../types/cliente";
+
+interface UseClienteFormOptions {
+  /** Se fornecido, o formulário opera em modo edição. */
+  clienteInicial?: Cliente;
+  onSucesso?: (cliente: Cliente) => void;
+}
+
+export function useClienteForm({
+  clienteInicial,
+  onSucesso,
+}: UseClienteFormOptions = {}) {
+  const [loading, setLoading] = useState(false);
+  const { showSuccess, showApiError } = useSnackbar();
+  const edicao = !!clienteInicial;
+
+  const form = useForm<ClienteSchemaInput, unknown, ClienteSchemaOutput>({
+    resolver: zodResolver(clienteSchema),
+    defaultValues: {
+      codigo: clienteInicial?.codigo ?? "",
+      nome: clienteInicial?.nome ?? "",
+      contato: clienteInicial?.contato ?? "",
+      municipio: clienteInicial?.municipio ?? "",
+      area: clienteInicial?.area ?? "",
+      observacoes: clienteInicial?.observacoes ?? "",
+    },
+  });
+
+  // Quando clienteInicial chegar (após fetch assíncrono), popula o formulário
+  useEffect(() => {
+    if (!clienteInicial) return;
+    form.reset({
+      codigo: clienteInicial.codigo,
+      nome: clienteInicial.nome,
+      contato: clienteInicial.contato ?? "",
+      municipio: clienteInicial.municipio ?? "",
+      area: clienteInicial.area ?? "",
+      observacoes: clienteInicial.observacoes ?? "",
+    });
+  }, [clienteInicial, form]);
+
+  const onSubmit = useCallback(
+    async (values: ClienteSchemaOutput) => {
+      setLoading(true);
+      try {
+        let salvo: Cliente;
+        if (edicao && clienteInicial) {
+          salvo = await clienteService.atualizar(clienteInicial.codigo, values);
+          showSuccess("Cliente atualizado com sucesso.");
+        } else {
+          salvo = await clienteService.criar(values);
+          showSuccess("Cliente criado com sucesso.");
+        }
+        onSucesso?.(salvo);
+      } catch (err) {
+        showApiError(err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [clienteInicial, edicao, onSucesso, showApiError, showSuccess],
+  );
+
+  return { form, loading, edicao, onSubmit: form.handleSubmit(onSubmit) };
+}

--- a/labas-web/src/hooks/useClientes.ts
+++ b/labas-web/src/hooks/useClientes.ts
@@ -52,8 +52,8 @@ export function useClientes(): UseClientesReturn {
 
       setLoading(true);
       try {
-        const response = await clienteService.listar(search);
-        setClientes(response.data);
+        const resultado = await clienteService.listar(search);
+        setClientes(resultado);
       } catch (err) {
         showApiError(err);
         setClientes([]);

--- a/labas-web/src/hooks/useLaudoForm.ts
+++ b/labas-web/src/hooks/useLaudoForm.ts
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useNavigate } from "react-router-dom";
+import {
+  laudoSchema,
+  type LaudoForm,
+  type LaudoFormInput,
+} from "../schemas/laudoSchemas";
+import { laudoService } from "../services/laudoService";
+import { useSnackbar } from "./useSnackbar";
+import type { AnaliseSoloPayload } from "../types/analise";
+
+const getTodayISO = () => new Date().toISOString().slice(0, 10);
+
+const normalizePayload = (data: LaudoForm): AnaliseSoloPayload => {
+  const entries = Object.entries(data).map(([key, value]) => [
+    key,
+    value === undefined || value === "" ? null : value,
+  ]);
+
+  return Object.fromEntries(entries) as AnaliseSoloPayload;
+};
+
+export function useLaudoForm() {
+  const navigate = useNavigate();
+  const { showSuccess, showApiError } = useSnackbar();
+  const [submitting, setSubmitting] = useState(false);
+
+  const form = useForm<LaudoFormInput, unknown, LaudoForm>({
+    resolver: zodResolver(laudoSchema),
+    defaultValues: {
+      n_lab: "",
+      cliente_codigo: "",
+      data_entrada: getTodayISO(),
+      data_saida: "",
+    },
+  });
+
+  const onSubmit = form.handleSubmit(async (data) => {
+    setSubmitting(true);
+    try {
+      await laudoService.criar(normalizePayload(data));
+      showSuccess("Laudo criado com sucesso.");
+      navigate("/laudos");
+    } catch (err) {
+      showApiError(err);
+    } finally {
+      setSubmitting(false);
+    }
+  });
+
+  return {
+    form,
+    submitting,
+    onSubmit,
+  };
+}

--- a/labas-web/src/hooks/useLaudos.ts
+++ b/labas-web/src/hooks/useLaudos.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { laudoService } from "../services/laudoService";
+import type { AnaliseSolo } from "../types/analise";
+
+interface UseLaudosResult {
+  laudos: AnaliseSolo[];
+  loading: boolean;
+  baixarPdf: (nLab: string) => Promise<void>;
+}
+
+const criarNomeArquivo = (nLab: string) =>
+  `laudo_${nLab.replace("/", "-")}.pdf`;
+
+export function useLaudos(): UseLaudosResult {
+  const [laudos, setLaudos] = useState<AnaliseSolo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const carregar = useCallback(async () => {
+    setLoading(true);
+    const response = await laudoService.listarMeusLaudos();
+    setLaudos(response.results);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void carregar();
+  }, [carregar]);
+
+  const baixarPdf = useCallback(async (nLab: string) => {
+    const blob = await laudoService.baixarPdfLaudo(nLab);
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = criarNomeArquivo(nLab);
+    link.style.display = "none";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
+  }, []);
+
+  return { laudos, loading, baixarPdf };
+}

--- a/labas-web/src/pages/clientes/ClienteFormPage.tsx
+++ b/labas-web/src/pages/clientes/ClienteFormPage.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Controller } from "react-hook-form";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useClienteForm } from "../../hooks/useClienteForm";
+import { clienteService } from "../../services/clienteService";
+import { useSnackbar } from "../../hooks/useSnackbar";
+import type { Cliente } from "../../types/cliente";
+
+export default function ClienteFormPage() {
+  const { codigo } = useParams<{ codigo?: string }>();
+  const navigate = useNavigate();
+  const { showApiError } = useSnackbar();
+  const edicao = !!codigo;
+
+  const [clienteInicial, setClienteInicial] = useState<Cliente | undefined>();
+  const [buscando, setBuscando] = useState(edicao);
+
+  useEffect(() => {
+    if (!edicao || !codigo) return;
+    clienteService
+      .buscar(codigo)
+      .then(setClienteInicial)
+      .catch(showApiError)
+      .finally(() => setBuscando(false));
+  }, [codigo, edicao, showApiError]);
+
+  const { form, loading, onSubmit } = useClienteForm({
+    clienteInicial,
+    onSucesso: () => navigate("/clientes"),
+  });
+
+  const {
+    control,
+    formState: { errors },
+  } = form;
+
+  if (buscando) {
+    return (
+      <Box display="flex" justifyContent="center" py={8}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
+        {edicao ? "Editar Cliente" : "Novo Cliente"}
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 3, maxWidth: 600 }}>
+        <Stack component="form" onSubmit={onSubmit} spacing={2}>
+          <Controller
+            name="codigo"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Código"
+                error={!!errors.codigo}
+                helperText={errors.codigo?.message}
+                disabled={edicao}
+                required
+              />
+            )}
+          />
+          <Controller
+            name="nome"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Nome / Razão Social"
+                error={!!errors.nome}
+                helperText={errors.nome?.message}
+                required
+              />
+            )}
+          />
+          <Controller
+            name="municipio"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Município"
+                error={!!errors.municipio}
+                helperText={errors.municipio?.message}
+              />
+            )}
+          />
+          <Controller
+            name="area"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Área"
+                error={!!errors.area}
+                helperText={errors.area?.message}
+              />
+            )}
+          />
+          <Controller
+            name="contato"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Contato"
+                error={!!errors.contato}
+                helperText={errors.contato?.message}
+              />
+            )}
+          />
+          <Controller
+            name="observacoes"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Observações"
+                multiline
+                rows={3}
+                error={!!errors.observacoes}
+                helperText={errors.observacoes?.message}
+              />
+            )}
+          />
+
+          <Stack direction="row" spacing={1} justifyContent="flex-end">
+            <Button variant="outlined" onClick={() => navigate("/clientes")}>
+              Cancelar
+            </Button>
+            <Button type="submit" variant="contained" disabled={loading}>
+              {loading ? (
+                <CircularProgress size={20} />
+              ) : edicao ? (
+                "Salvar"
+              ) : (
+                "Criar"
+              )}
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}

--- a/labas-web/src/pages/clientes/ClientesPage.tsx
+++ b/labas-web/src/pages/clientes/ClientesPage.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import { useNavigate } from "react-router-dom";
+import { clienteService } from "../../services/clienteService";
+import { useSnackbar } from "../../hooks/useSnackbar";
+import type { Cliente } from "../../types/cliente";
+
+export default function ClientesPage() {
+  const navigate = useNavigate();
+  const { showApiError, showSuccess } = useSnackbar();
+  const [clientes, setClientes] = useState<Cliente[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const carregar = useCallback(async () => {
+    setLoading(true);
+    try {
+      const resultado = await clienteService.listar();
+      setClientes(resultado);
+    } catch (err) {
+      showApiError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [showApiError]);
+
+  useEffect(() => {
+    void carregar();
+  }, [carregar]);
+
+  const handleRemover = useCallback(
+    async (codigo: string) => {
+      if (!window.confirm(`Remover cliente ${codigo}?`)) return;
+      try {
+        await clienteService.remover(codigo);
+        showSuccess("Cliente removido.");
+        setClientes((prev) => prev.filter((c) => c.codigo !== codigo));
+      } catch (err) {
+        showApiError(err);
+      }
+    },
+    [showApiError, showSuccess],
+  );
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" py={8}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 3,
+        }}
+      >
+        <Typography variant="h5" fontWeight={700} color="primary">
+          Clientes
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => navigate("/clientes/novo")}
+        >
+          Novo Cliente
+        </Button>
+      </Box>
+
+      {clientes.length === 0 ? (
+        <Alert severity="info">Nenhum cliente cadastrado.</Alert>
+      ) : (
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Código</TableCell>
+                <TableCell>Nome</TableCell>
+                <TableCell>Município</TableCell>
+                <TableCell>Área</TableCell>
+                <TableCell>Contato</TableCell>
+                <TableCell align="right">Ações</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {clientes.map((c) => (
+                <TableRow key={c.codigo} hover>
+                  <TableCell>{c.codigo}</TableCell>
+                  <TableCell>{c.nome}</TableCell>
+                  <TableCell>{c.municipio ?? "—"}</TableCell>
+                  <TableCell>{c.area ?? "—"}</TableCell>
+                  <TableCell>{c.contato ?? "—"}</TableCell>
+                  <TableCell align="right">
+                    <Tooltip title="Editar">
+                      <IconButton
+                        size="small"
+                        onClick={() => navigate(`/clientes/${c.codigo}/editar`)}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Remover">
+                      <IconButton
+                        size="small"
+                        color="error"
+                        onClick={() => handleRemover(c.codigo)}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+}

--- a/labas-web/src/pages/dashboard/DashboardPlaceholder.tsx
+++ b/labas-web/src/pages/dashboard/DashboardPlaceholder.tsx
@@ -1,22 +1,106 @@
-/**
- * Placeholder temporário da Dashboard.
- * Substituir pela DashboardPage real na Sprint 2 da Sabrina.
- */
-import Typography from "@mui/material/Typography";
-import Box from "@mui/material/Box";
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CircularProgress,
+  Typography,
+} from "@mui/material";
+import { NavLink } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
+import { useLaudos } from "../../hooks/useLaudos";
+import ClientDashboard from "./components/ClientDashboard";
 
-export default function DashboardPlaceholder() {
-  const { user } = useAuth();
+const staffCards = [
+  {
+    title: "Laudos",
+    description: "Criar e acompanhar laudos de análise.",
+    to: "/laudos/novo",
+  },
+  {
+    title: "Calibração",
+    description: "Gerenciar baterias e curvas de calibração.",
+    to: "/calibracao",
+  },
+  {
+    title: "Operação em Lote",
+    description: "Inserir leituras em lote na bancada.",
+    to: "/entrada-lote",
+  },
+];
+
+function StaffDashboard({ username }: { username: string }) {
+  return (
+    <Box>
+      <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
+        Olá, {username} 👋
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Acesso rápido às rotinas do laboratório.
+      </Typography>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
+          gap: 2,
+        }}
+      >
+        {staffCards.map((card) => (
+          <Card key={card.to} variant="outlined">
+            <CardContent>
+              <Typography variant="h6" fontWeight={700} gutterBottom>
+                {card.title}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {card.description}
+              </Typography>
+            </CardContent>
+            <CardActions sx={{ px: 2, pb: 2 }}>
+              <Button
+                component={NavLink}
+                to={card.to}
+                variant="contained"
+                size="small"
+              >
+                Acessar
+              </Button>
+            </CardActions>
+          </Card>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+function ClienteDashboardWrapper({ username }: { username: string }) {
+  const { laudos, loading, baixarPdf } = useLaudos();
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" py={8}>
+        <CircularProgress />
+      </Box>
+    );
+  }
 
   return (
     <Box>
       <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
-        Olá, {user?.username} 👋
+        Olá, {username} 👋
       </Typography>
-      <Typography variant="body2" color="text.secondary">
-        Dashboard em construção.
-      </Typography>
+      <ClientDashboard laudos={laudos} onBaixarPdf={baixarPdf} />
     </Box>
+  );
+}
+
+export default function DashboardPlaceholder() {
+  const { user, isStaff } = useAuth();
+  const username = user?.username ?? "";
+
+  return isStaff ? (
+    <StaffDashboard username={username} />
+  ) : (
+    <ClienteDashboardWrapper username={username} />
   );
 }

--- a/labas-web/src/pages/dashboard/components/ClientDashboard.tsx
+++ b/labas-web/src/pages/dashboard/components/ClientDashboard.tsx
@@ -1,0 +1,118 @@
+import {
+  Box,
+  Button,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  Typography,
+} from "@mui/material";
+import StatusChip from "../../../components/shared/StatusChip";
+import type { AnaliseSolo } from "../../../types/analise";
+
+interface Props {
+  laudos: AnaliseSolo[];
+  onBaixarPdf: (nLab: string) => void;
+}
+
+const formatarData = (value: string) => {
+  const data = new Date(value);
+  if (Number.isNaN(data.getTime())) {
+    return value;
+  }
+  return data.toLocaleDateString("pt-BR");
+};
+
+const ordenarPorEntrada = (a: AnaliseSolo, b: AnaliseSolo) =>
+  new Date(b.data_entrada).getTime() - new Date(a.data_entrada).getTime();
+
+export default function ClientDashboard({ laudos, onBaixarPdf }: Props) {
+  const recentes = [...laudos].sort(ordenarPorEntrada).slice(0, 5);
+
+  return (
+    <Grid container spacing={3}>
+      <Grid size={{ xs: 12, md: 8 }}>
+        <Paper sx={{ p: 3, mb: 3 }} variant="outlined">
+          <Typography variant="h6" fontWeight={700} gutterBottom>
+            Servicos do Laboratorio
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Analises quimicas e fisicas de solo, com laudos oficiais e
+            acompanhamento direto pelo portal.
+          </Typography>
+        </Paper>
+
+        <Paper sx={{ p: 3 }} variant="outlined">
+          <Typography variant="h6" fontWeight={700} gutterBottom>
+            Meus laudos mais recentes
+          </Typography>
+          <List disablePadding>
+            {recentes.map((laudo) => {
+              const status = laudo.data_saida ? "concluido" : "em_andamento";
+
+              return (
+                <ListItem
+                  key={laudo.n_lab}
+                  divider
+                  sx={{ px: 0, alignItems: "flex-start" }}
+                  secondaryAction={
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => onBaixarPdf(laudo.n_lab)}
+                    >
+                      Baixar PDF
+                    </Button>
+                  }
+                >
+                  <ListItemText
+                    primary={
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                          flexWrap: "wrap",
+                        }}
+                      >
+                        <Typography variant="subtitle2" fontWeight={700}>
+                          {laudo.n_lab}
+                        </Typography>
+                        <StatusChip status={status} />
+                      </Box>
+                    }
+                    secondary={`Entrada: ${formatarData(laudo.data_entrada)}`}
+                  />
+                </ListItem>
+              );
+            })}
+            {recentes.length === 0 && (
+              <ListItem sx={{ px: 0 }}>
+                <ListItemText
+                  primary="Nenhum laudo encontrado"
+                  secondary="Quando houver laudos, eles aparecerao aqui."
+                />
+              </ListItem>
+            )}
+          </List>
+        </Paper>
+      </Grid>
+
+      <Grid size={{ xs: 12, md: 4 }}>
+        <Paper sx={{ p: 3 }} variant="outlined">
+          <Typography variant="h6" fontWeight={700} gutterBottom>
+            Suporte ao cliente
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Precisa de ajuda com seus laudos? Fale com nossa equipe.
+          </Typography>
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="body2">Telefone: (34) 3232-0000</Typography>
+            <Typography variant="body2">Email: suporte@labas.com.br</Typography>
+          </Box>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+}

--- a/labas-web/src/pages/laudos/LaudoFormPage.tsx
+++ b/labas-web/src/pages/laudos/LaudoFormPage.tsx
@@ -1,0 +1,363 @@
+import { useState } from "react";
+import { Controller } from "react-hook-form";
+import type { InputHTMLAttributes } from "react";
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  Grid,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import PageHeader from "../../components/shared/PageHeader";
+import LoadingOverlay from "../../components/shared/LoadingOverlay";
+import { useLaudoForm } from "../../hooks/useLaudoForm";
+import { useClientes } from "../../hooks/useClientes";
+import type { Cliente } from "../../types/cliente";
+import type { LaudoForm } from "../../schemas/laudoSchemas";
+
+const decimalInputProps = {
+  inputMode: "decimal" as const,
+  pattern: "[0-9]*[.,]?[0-9]*",
+};
+
+type FieldName = keyof LaudoForm;
+
+type FieldConfig = {
+  name: FieldName;
+  label: string;
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
+};
+
+const PH_FIELDS: FieldConfig[] = [
+  { name: "ph_agua", label: "pH água" },
+  { name: "ph_cacl2", label: "pH CaCl₂" },
+  { name: "ph_kcl", label: "pH KCl" },
+];
+
+const ESPECTRO_FIELDS: FieldConfig[] = [
+  { name: "p_m", label: "P Mehlich (mg/dm³)" },
+  { name: "p_r", label: "P Resina (mg/dm³)" },
+  { name: "p_rem", label: "P Rem (mg/L)" },
+  { name: "mo", label: "Matéria Orgânica (dag/kg)" },
+  { name: "s", label: "Enxofre (mg/dm³)" },
+  { name: "b", label: "Boro (mg/dm³)" },
+];
+
+const FOTOMETRO_FIELDS: FieldConfig[] = [
+  { name: "k", label: "Potássio (mg/dm³)" },
+  { name: "na", label: "Sódio (mg/dm³)" },
+];
+
+const ABSORCAO_FIELDS: FieldConfig[] = [
+  { name: "ca", label: "Cálcio (cmolc/dm³)" },
+  { name: "mg", label: "Magnésio (cmolc/dm³)" },
+  { name: "cu", label: "Cobre (mg/dm³)" },
+  { name: "fe", label: "Ferro (mg/dm³)" },
+  { name: "mn", label: "Manganês (mg/dm³)" },
+  { name: "zn", label: "Zinco (mg/dm³)" },
+];
+
+const TITULACAO_FIELDS: FieldConfig[] = [
+  { name: "al", label: "Alumínio (cmolc/dm³)" },
+  { name: "h_al", label: "Acidez Potencial (cmolc/dm³)" },
+];
+
+const GRANULOMETRIA_FIELDS: FieldConfig[] = [
+  { name: "areia", label: "Areia (%)" },
+  { name: "argila", label: "Argila (%)" },
+  { name: "silte", label: "Silte (%)" },
+];
+
+const renderNumberField = (
+  field: FieldConfig,
+  getErrorMessage: (name: FieldName) => string | undefined,
+  register: ReturnType<typeof useLaudoForm>["form"]["register"],
+  disabled: boolean,
+) => (
+  <Grid size={{ xs: 12, sm: 6, md: 4 }} key={field.name}>
+    <TextField
+      fullWidth
+      size="small"
+      label={field.label}
+      type="text"
+      inputProps={field.inputProps ?? decimalInputProps}
+      error={!!getErrorMessage(field.name)}
+      helperText={getErrorMessage(field.name)}
+      disabled={disabled}
+      {...register(field.name)}
+    />
+  </Grid>
+);
+
+export default function LaudoFormPage() {
+  const { form, submitting, onSubmit } = useLaudoForm();
+  const { clientes, loading, buscar, limpar } = useClientes();
+  const [clienteSelecionado, setClienteSelecionado] = useState<Cliente | null>(
+    null,
+  );
+  const [clienteInput, setClienteInput] = useState("");
+
+  const getErrorMessage = (name: FieldName) =>
+    form.formState.errors[name]?.message as string | undefined;
+
+  const handleClienteInput = (_: React.SyntheticEvent, value: string) => {
+    setClienteInput(value);
+    if (value.trim().length === 0) {
+      if (clienteSelecionado) {
+        setClienteSelecionado(null);
+        form.setValue("cliente_codigo", "", {
+          shouldDirty: true,
+          shouldValidate: true,
+        });
+      }
+      limpar();
+      return;
+    }
+    if (value.trim().length < 2) {
+      limpar();
+      return;
+    }
+    buscar(value);
+  };
+
+  const handleClienteChange = (
+    _: React.SyntheticEvent,
+    value: Cliente | null,
+  ) => {
+    setClienteSelecionado(value);
+  };
+
+  return (
+    <Box component="form" onSubmit={onSubmit} noValidate>
+      <LoadingOverlay open={submitting} message="Salvando laudo..." />
+
+      <PageHeader
+        title="Novo Laudo"
+        subtitle="Cadastro completo das análises da amostra"
+      />
+
+      <Alert severity="info" sx={{ mb: 3 }}>
+        Campos calculados (SB, CTC, V%, m%) são preenchidos automaticamente após
+        salvar.
+      </Alert>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Dados gerais
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Nº do laudo"
+              placeholder="2026/001"
+              error={!!getErrorMessage("n_lab")}
+              helperText={getErrorMessage("n_lab")}
+              disabled={submitting}
+              {...form.register("n_lab")}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Data de entrada"
+              type="date"
+              InputLabelProps={{ shrink: true }}
+              error={!!getErrorMessage("data_entrada")}
+              helperText={getErrorMessage("data_entrada")}
+              disabled={submitting}
+              {...form.register("data_entrada")}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Data de saída"
+              type="date"
+              InputLabelProps={{ shrink: true }}
+              error={!!getErrorMessage("data_saida")}
+              helperText={getErrorMessage("data_saida")}
+              disabled={submitting}
+              {...form.register("data_saida")}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 8 }}>
+            <Controller
+              control={form.control}
+              name="cliente_codigo"
+              render={({ field, fieldState }) => (
+                <Autocomplete
+                  options={clientes}
+                  value={clienteSelecionado}
+                  inputValue={clienteInput}
+                  onInputChange={handleClienteInput}
+                  onChange={(event, value) => {
+                    handleClienteChange(event, value);
+                    field.onChange(value?.codigo ?? "");
+                  }}
+                  onBlur={field.onBlur}
+                  loading={loading}
+                  noOptionsText={
+                    clienteInput.length < 2
+                      ? "Digite pelo menos 2 caracteres"
+                      : "Nenhum cliente encontrado"
+                  }
+                  getOptionLabel={(option) =>
+                    `${option.codigo} — ${option.nome}`
+                  }
+                  isOptionEqualToValue={(option, value) =>
+                    option.codigo === value.codigo
+                  }
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Cliente"
+                      size="small"
+                      error={!!fieldState.error}
+                      helperText={fieldState.error?.message}
+                    />
+                  )}
+                />
+              )}
+            />
+          </Grid>
+
+          <Grid size={{ xs: 12, md: 4 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Código do cliente"
+              value={clienteSelecionado?.codigo ?? ""}
+              InputProps={{ readOnly: true }}
+              placeholder="Selecione um cliente"
+            />
+          </Grid>
+
+          {clienteSelecionado && (
+            <Grid size={12}>
+              <Typography variant="body2" color="text.secondary">
+                {clienteSelecionado.municipio} • {clienteSelecionado.area}
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          pH-metro
+        </Typography>
+        <Grid container spacing={2}>
+          {PH_FIELDS.map((field) =>
+            renderNumberField(
+              field,
+              getErrorMessage,
+              form.register,
+              submitting,
+            ),
+          )}
+        </Grid>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Espectrofotômetro
+        </Typography>
+        <Grid container spacing={2}>
+          {ESPECTRO_FIELDS.map((field) =>
+            renderNumberField(
+              field,
+              getErrorMessage,
+              form.register,
+              submitting,
+            ),
+          )}
+        </Grid>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Fotômetro de chama
+        </Typography>
+        <Grid container spacing={2}>
+          {FOTOMETRO_FIELDS.map((field) =>
+            renderNumberField(
+              field,
+              getErrorMessage,
+              form.register,
+              submitting,
+            ),
+          )}
+        </Grid>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Absorção atômica
+        </Typography>
+        <Grid container spacing={2}>
+          {ABSORCAO_FIELDS.map((field) =>
+            renderNumberField(
+              field,
+              getErrorMessage,
+              form.register,
+              submitting,
+            ),
+          )}
+        </Grid>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Titulação
+        </Typography>
+        <Grid container spacing={2}>
+          {TITULACAO_FIELDS.map((field) =>
+            renderNumberField(
+              field,
+              getErrorMessage,
+              form.register,
+              submitting,
+            ),
+          )}
+        </Grid>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Granulometria
+        </Typography>
+        <Grid container spacing={2}>
+          {GRANULOMETRIA_FIELDS.map((field) =>
+            renderNumberField(
+              field,
+              getErrorMessage,
+              form.register,
+              submitting,
+            ),
+          )}
+        </Grid>
+      </Paper>
+
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2} mb={4}>
+        <Button variant="outlined" component={RouterLink} to="/laudos">
+          Voltar
+        </Button>
+        <Button type="submit" variant="contained" disabled={submitting}>
+          {submitting ? "Salvando..." : "Salvar laudo"}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/labas-web/src/schemas/clienteSchemas.ts
+++ b/labas-web/src/schemas/clienteSchemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const clienteSchema = z.object({
+  codigo: z
+    .string()
+    .min(1, "Código é obrigatório")
+    .max(50, "Máximo de 50 caracteres"),
+  nome: z
+    .string()
+    .min(1, "Nome é obrigatório")
+    .max(255, "Máximo de 255 caracteres"),
+  contato: z.string().max(100, "Máximo de 100 caracteres").optional(),
+  municipio: z.string().max(100, "Máximo de 100 caracteres").optional(),
+  area: z.string().max(100, "Máximo de 100 caracteres").optional(),
+  observacoes: z.string().optional(),
+});
+
+export type ClienteSchemaInput = z.input<typeof clienteSchema>;
+export type ClienteSchemaOutput = z.output<typeof clienteSchema>;

--- a/labas-web/src/schemas/laudoSchemas.ts
+++ b/labas-web/src/schemas/laudoSchemas.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data inválida");
+
+const nullableNumber = z
+  .union([z.coerce.number(), z.literal("")])
+  .transform((value) => (value === "" ? null : value));
+
+const optionalDate = z.union([dateSchema, z.literal("")]);
+
+export const laudoSchema = z.object({
+  n_lab: z
+    .string()
+    .min(1, "Nº do laudo é obrigatório")
+    .regex(/^\d{4}\/\d{3}$/, "Use o formato AAAA/NNN"),
+  cliente_codigo: z.string().min(1, "Cliente é obrigatório"),
+  data_entrada: dateSchema,
+  data_saida: optionalDate,
+  ph_agua: nullableNumber.optional(),
+  ph_cacl2: nullableNumber.optional(),
+  ph_kcl: nullableNumber.optional(),
+  p_m: nullableNumber.optional(),
+  p_r: nullableNumber.optional(),
+  p_rem: nullableNumber.optional(),
+  mo: nullableNumber.optional(),
+  s: nullableNumber.optional(),
+  b: nullableNumber.optional(),
+  k: nullableNumber.optional(),
+  na: nullableNumber.optional(),
+  ca: nullableNumber.optional(),
+  mg: nullableNumber.optional(),
+  cu: nullableNumber.optional(),
+  fe: nullableNumber.optional(),
+  mn: nullableNumber.optional(),
+  zn: nullableNumber.optional(),
+  al: nullableNumber.optional(),
+  h_al: nullableNumber.optional(),
+  areia: nullableNumber.optional(),
+  argila: nullableNumber.optional(),
+  silte: nullableNumber.optional(),
+});
+
+export type LaudoFormInput = z.input<typeof laudoSchema>;
+export type LaudoForm = z.output<typeof laudoSchema>;

--- a/labas-web/src/services/clienteService.ts
+++ b/labas-web/src/services/clienteService.ts
@@ -1,28 +1,42 @@
 // src/services/clienteService.ts
 import { api } from "./api";
-import type { Cliente } from "../types/cliente";
+import type { Cliente, ClientePayload } from "../types/cliente";
 
-/**
- * Serviço de acesso à API de clientes.
- *
- * Usado principalmente no Autocomplete do formulário de laudo
- * para que o staff selecione o cliente ao criar uma análise.
- *
- * Endpoint: GET /api/clientes/?search=<termo>
- */
 export const clienteService = {
-  /**
-   * Lista clientes com suporte a busca por nome ou código.
-   * @param search - Termo de busca (opcional). Filtra por nome ou código_cliente.
-   */
-  listar: (search?: string) =>
-    api.get<Cliente[]>("/clientes/", {
-      params: search ? { search } : undefined,
-    }),
+  /** Lista clientes. Suporta filtro por ?search= (nome ou código). */
+  listar: async (search?: string): Promise<Cliente[]> => {
+    const { data } = await api.get<Cliente[] | { results: Cliente[] }>(
+      "/clientes/",
+      {
+        params: search ? { search } : undefined,
+      },
+    );
+    return Array.isArray(data) ? data : data.results;
+  },
 
-  /**
-   * Busca um cliente específico pelo código.
-   * @param codigo - Código único do cliente (ex: "2026-001")
-   */
-  buscar: (codigo: string) => api.get<Cliente>(`/clientes/${codigo}/`),
+  /** Busca um cliente pelo código. */
+  buscar: async (codigo: string): Promise<Cliente> => {
+    const { data } = await api.get<Cliente>(`/clientes/${codigo}/`);
+    return data;
+  },
+
+  /** Cria um novo cliente (staff only). */
+  criar: async (payload: ClientePayload): Promise<Cliente> => {
+    const { data } = await api.post<Cliente>("/clientes/", payload);
+    return data;
+  },
+
+  /** Atualiza parcialmente um cliente (staff only). */
+  atualizar: async (
+    codigo: string,
+    payload: Partial<ClientePayload>,
+  ): Promise<Cliente> => {
+    const { data } = await api.patch<Cliente>(`/clientes/${codigo}/`, payload);
+    return data;
+  },
+
+  /** Remove um cliente (staff only). */
+  remover: async (codigo: string): Promise<void> => {
+    await api.delete(`/clientes/${codigo}/`);
+  },
 };

--- a/labas-web/src/services/laudoService.ts
+++ b/labas-web/src/services/laudoService.ts
@@ -1,0 +1,79 @@
+import { api } from "./api";
+import type {
+  AnaliseSolo,
+  AnaliseSoloPayload,
+  PaginatedResponse,
+} from "../types/analise";
+
+const BASE = "/meus-laudos/";
+
+const normalizarNLab = (nLab: string) => nLab.replace(/^\/+|\/+$/g, "");
+
+export const laudoService = {
+  /** Lista laudos com paginação padrão do DRF. */
+  async listar(page?: number): Promise<PaginatedResponse<AnaliseSolo>> {
+    const { data } = await api.get(BASE, {
+      params: page ? { page } : undefined,
+    });
+    if (Array.isArray(data)) {
+      return { count: data.length, next: null, previous: null, results: data };
+    }
+    return data as PaginatedResponse<AnaliseSolo>;
+  },
+
+  /** Lista os laudos do cliente logado (rota /meus-laudos/). */
+  async listarMeusLaudos(): Promise<PaginatedResponse<AnaliseSolo>> {
+    const { data } = await api.get(BASE);
+    if (Array.isArray(data)) {
+      return { count: data.length, next: null, previous: null, results: data };
+    }
+    return data as PaginatedResponse<AnaliseSolo>;
+  },
+
+  /** Cria um novo laudo (somente staff). */
+  async criar(payload: AnaliseSoloPayload): Promise<AnaliseSolo> {
+    const { data } = await api.post<AnaliseSolo>(BASE, payload);
+    return data;
+  },
+
+  /** Busca detalhe de um laudo pelo N Lab. */
+  async buscar(nLab: string): Promise<AnaliseSolo> {
+    const { data } = await api.get<AnaliseSolo>(
+      `${BASE}${normalizarNLab(nLab)}/`,
+    );
+    return data;
+  },
+
+  /** Atualiza parcialmente um laudo (somente staff). */
+  async atualizar(
+    nLab: string,
+    payload: Partial<AnaliseSoloPayload>,
+  ): Promise<AnaliseSolo> {
+    const { data } = await api.patch<AnaliseSolo>(
+      `${BASE}${normalizarNLab(nLab)}/`,
+      payload,
+    );
+    return data;
+  },
+
+  /** Remove um laudo (somente staff). */
+  async remover(nLab: string): Promise<void> {
+    await api.delete(`${BASE}${normalizarNLab(nLab)}/`);
+  },
+
+  /** Gera o PDF oficial do laudo. */
+  async baixarPdf(nLab: string): Promise<Blob> {
+    const { data } = await api.get(`${BASE}${normalizarNLab(nLab)}/pdf/`, {
+      responseType: "blob",
+    });
+    return data as Blob;
+  },
+
+  /** Baixa o PDF do laudo do cliente logado. */
+  async baixarPdfLaudo(nLab: string): Promise<Blob> {
+    const { data } = await api.get(`${BASE}${normalizarNLab(nLab)}/pdf/`, {
+      responseType: "blob",
+    });
+    return data as Blob;
+  },
+};

--- a/labas-web/src/types/analise.ts
+++ b/labas-web/src/types/analise.ts
@@ -158,3 +158,11 @@ export type AnaliseSoloPayload = Omit<
   /** Código do cliente — substitui o objeto `cliente` no payload de envio */
   cliente_codigo: string;
 };
+
+/** Resposta paginada padrão do DRF. */
+export interface PaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}

--- a/labas-web/src/types/cliente.ts
+++ b/labas-web/src/types/cliente.ts
@@ -1,9 +1,19 @@
-/*
- * Interface que representa um cliente, com as seguintes propriedades:
- */
+/** Representa um cliente (Produtor Rural) conforme o model Django. */
 export interface Cliente {
   codigo: string;
   nome: string;
-  municipio: string;
-  area: string;
+  contato: string | null;
+  municipio: string | null;
+  area: string | null;
+  observacoes: string | null;
 }
+
+/** Payload para criar ou atualizar um cliente via API (staff only). */
+export type ClientePayload = {
+  codigo: string;
+  nome: string;
+  contato?: string;
+  municipio?: string;
+  area?: string;
+  observacoes?: string;
+};


### PR DESCRIPTION
## O que foi feito

### Sprint 4 — Laudos + Dashboard por perfil
- Formulário de criação de laudo (`/laudos/novo`)
- Dashboard condicional: staff vê cards de acesso rápido, cliente vê laudos recentes com download de PDF
- `laudoService`, `useLaudoForm`, `useLaudos`, `ClientDashboard`

### Sprint 5 — CRUD de Clientes (staff only)
- Backend: `ClienteCadastroSerializer`, `ClienteListCreateView`, `ClienteDetailView`, rotas `/api/clientes/`
- Frontend: `ClientesPage` (tabela), `ClienteFormPage` (criar/editar), rotas e link na sidebar