### PR TITLE
feat(laudo): corrigir criação de laudo e tratar erros de formulário

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -291,22 +291,27 @@ Em seguida, garanta que a palavra `node_modules/` está escrita dentro do seu ar
 - ✅ Sprint 3: Operacao em Lote (rota /entrada-lote, UI profissional)
 - ✅ Sprint 4: formulario de criacao de laudo + dashboard por perfil (staff/cliente)
   - `src/services/laudoService.ts` — CRUD + PDF (lidar, criar, buscar, atualizar, remover, baixarPdf, listarMeusLaudos, baixarPdfLaudo)
-  - `src/hooks/useLaudoForm.ts` — hook de criacao com Zod + react-hook-form
+  - `src/hooks/useLaudoForm.ts` — hook de criacao com Zod + react-hook-form (incl. mapeamento de erros de API para campos do form)
   - `src/hooks/useLaudos.ts` — listagem + download de PDF para cliente
   - `src/schemas/laudoSchemas.ts` — schema Zod com input/output types
   - `src/pages/laudos/LaudoFormPage.tsx` — formulario de criacao (rota /laudos/novo, staff only)
   - `src/pages/dashboard/DashboardPlaceholder.tsx` — staff ve cards, cliente ve ClientDashboard
   - `src/pages/dashboard/components/ClientDashboard.tsx` — area do cliente com laudos recentes e PDF
-- 🔲 Sprint 5: CRUD de clientes (staff only)
-  - **Backend:** serializer `ClienteCadastroSerializer` + views `ClienteListCreateView` / `ClienteDetailView` + rotas `/clientes/` e `/clientes/<codigo>/`
-  - **Frontend — Bloco 1:** atualizar `src/types/cliente.ts` + `src/services/clienteService.ts` (adicionar criar, atualizar, remover)
-  - **Frontend — Bloco 2:** `src/schemas/clienteSchemas.ts` (Zod) + `src/hooks/useClientes.ts` (listagem) + `src/hooks/useClienteForm.ts` (criacao/edicao)
-  - **Frontend — Bloco 3:** `src/pages/clientes/ClientesPage.tsx` (tabela MUI com acoes) + `src/pages/clientes/ClienteFormPage.tsx` (formulario criar/editar) + rota `/clientes` (staff only) + link na sidebar
+  - `backend/serializers.py` — UniqueValidator em n_lab + create()/update() com resolucao de cliente_codigo
+- ✅ Sprint 5: CRUD de clientes (staff only)
+  - **Backend:** `ClienteCadastroSerializer` + `ClienteListCreateView` / `ClienteDetailView` + rotas `/clientes/` e `/clientes/<codigo>/`
+  - `src/types/cliente.ts` + `src/services/clienteService.ts`
+  - `src/schemas/clienteSchemas.ts` + `src/hooks/useClientes.ts` + `src/hooks/useClienteForm.ts`
+  - `src/pages/clientes/ClientesPage.tsx` + `src/pages/clientes/ClienteFormPage.tsx`
+- 🔲 Sprint 6: Pagina de laudos — lista completa + editar + excluir (staff) — branch `feat/gabriel/laudos-page`
+  - **Bloco 1 — Hook:** `src/hooks/useLaudos.ts` — refatorar para suportar listagem completa (staff ve todos, cliente ve os seus), paginacao, delete com confirmacao
+  - **Bloco 2 — UI:** `src/pages/laudos/LaudosPage.tsx` — tabela MUI DataGrid com acoes (ver PDF, editar, excluir); botao "Novo Laudo" para staff; filtro por n_lab/cliente
+  - **Bloco 3 — Edicao:** `src/pages/laudos/LaudoEditPage.tsx` — rota `/laudos/:nLab/editar` (staff only); reusa `LaudoFormPage` com dados pre-carregados via `laudoService.buscar()`
 
 ### Sabrina — `feat/sabrina/laudos`
 
-- Sprint 1: dashboard e lista de laudos
-- Sprint 2: detalhe do laudo e PDF
+- ~~Sprint 1: dashboard e lista de laudos~~ — assumido pelo Gabriel (Sprint 6)
+- ~~Sprint 2: detalhe do laudo e PDF~~ — assumido pelo Gabriel (Sprint 6)
 
 Zonas sem conflito:
 

--- a/backend/src/infrastructure/web/serializers.py
+++ b/backend/src/infrastructure/web/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.validators import UniqueValidator
 from django.core.validators import RegexValidator
 from django.contrib.auth.models import User
 from django.db import transaction, IntegrityError
@@ -110,21 +111,53 @@ class AnaliseSoloSerializer(serializers.ModelSerializer):
     # Inclui os dados do cliente de forma aninhada apenas para leitura
     cliente = ClienteSerializer(read_only=True)
 
-    # Aplica regra de formato para o identificador do laboratorio
+    # Campo de escrita: recebe o codigo do cliente para resolucao no create()
+    cliente_codigo = serializers.CharField(write_only=True, required=True)
+
+    # Aplica regra de formato e unicidade para o identificador do laboratorio
     n_lab = serializers.CharField(
         validators=[
             RegexValidator(
                 regex=r"^\d{4}/.+$",
                 message="O padrao do N Lab deve ser ANO/NUMERO ex 2026/001",
-            )
+            ),
+            UniqueValidator(
+                queryset=AnaliseSolo.objects.all(),
+                message="Ja existe um laudo registrado com este N Lab.",
+            ),
         ]
     )
+
+    def create(self, validated_data):
+        cliente_codigo = validated_data.pop("cliente_codigo")
+        try:
+            cliente = Cliente.objects.get(codigo=cliente_codigo)
+        except Cliente.DoesNotExist:
+            raise serializers.ValidationError(
+                {"cliente_codigo": "Cliente nao encontrado com este codigo."}
+            )
+        return AnaliseSolo.objects.create(cliente=cliente, **validated_data)
+
+    def update(self, instance, validated_data):
+        cliente_codigo = validated_data.pop("cliente_codigo", None)
+        if cliente_codigo:
+            try:
+                instance.cliente = Cliente.objects.get(codigo=cliente_codigo)
+            except Cliente.DoesNotExist:
+                raise serializers.ValidationError(
+                    {"cliente_codigo": "Cliente nao encontrado com este codigo."}
+                )
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+        return instance
 
     class Meta:
         model = AnaliseSolo
         # Mapeia todos os atributos quimicos e fisicos para o formato JSON
         fields = [
             "n_lab",
+            "cliente_codigo",
             "cliente",
             "data_entrada",
             "data_saida",

--- a/labas-web/src/hooks/useLaudoForm.ts
+++ b/labas-web/src/hooks/useLaudoForm.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import type { FieldPath } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "react-router-dom";
 import {
@@ -44,6 +45,29 @@ export function useLaudoForm() {
       showSuccess("Laudo criado com sucesso.");
       navigate("/laudos");
     } catch (err) {
+      // Mapeia erros de campo (400) de volta para os inputs do formulário
+      const responseData = (err as { response?: { data?: unknown } })?.response
+        ?.data;
+      if (responseData && typeof responseData === "object") {
+        let hasFieldError = false;
+        (
+          Object.entries(responseData as Record<string, unknown>) as [
+            FieldPath<LaudoFormInput>,
+            unknown,
+          ][]
+        ).forEach(([field, msgs]) => {
+          const message = Array.isArray(msgs) ? msgs[0] : String(msgs);
+          if (message && field in laudoSchema.shape) {
+            form.setError(field, { type: "server", message });
+            hasFieldError = true;
+          }
+        });
+        // Exibe no Snackbar apenas o que não mapeou para um campo do form
+        if (!hasFieldError) {
+          showApiError(err);
+        }
+        return;
+      }
       showApiError(err);
     } finally {
       setSubmitting(false);

--- a/labas-web/src/pages/laudos/LaudoFormPage.tsx
+++ b/labas-web/src/pages/laudos/LaudoFormPage.tsx
@@ -142,8 +142,11 @@ export default function LaudoFormPage() {
       />
 
       <Alert severity="info" sx={{ mb: 3 }}>
-        Campos calculados (SB, CTC, V%, m%) são preenchidos automaticamente após
-        salvar.
+        Crie o laudo com no mínimo <strong>Nº do laudo</strong> e{" "}
+        <strong>Cliente</strong>. Os valores químicos podem ser deixados em
+        branco e preenchidos depois via <strong>Operação em Lote</strong>.
+        Campos calculados (SB, CTC, V%, m%) são preenchidos automaticamente pelo
+        sistema.
       </Alert>
 
       <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
@@ -158,7 +161,9 @@ export default function LaudoFormPage() {
               label="Nº do laudo"
               placeholder="2026/001"
               error={!!getErrorMessage("n_lab")}
-              helperText={getErrorMessage("n_lab")}
+              helperText={
+                getErrorMessage("n_lab") ?? "Formato: AAAA/NNN — ex: 2026/001"
+              }
               disabled={submitting}
               {...form.register("n_lab")}
             />


### PR DESCRIPTION
## O que muda
- Erro 500 ao criar laudo corrigido (cliente_id nao chegava ao serializer)
- Laudo com n_lab duplicado agora retorna 400 com mensagem clara
- Erros de campo da API aparecem embaixo do input correspondente no form
- UX: hint de formato no campo n_lab + info sobre Operacao em Lote
- Copilot instructions: Sprint 5 marcada como OK, Sprint 6 planejada