### PR TITLE
feat: DialogCorrecaoAnalise + data_saida + edição de amostra (Sprint 8)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 > **Tech Lead:** Gabriel Azevedo | **Dev:** Sabrina  
 > **Stack:** React 19 + TypeScript + MUI v7 + React Hook Form + Zod + Axios  
 > **API:** Django REST Framework + JWT (SimpleJWT) — `http://localhost:8000/api/`  
-> **Última atualização:** 06/04/2026
+> **Última atualização:** 07/04/2026
 
 ---
 
@@ -18,8 +18,10 @@
 7. Padroes de codigo
 8. Testes automatizados
 9. Checklist unico de entrega
-10. Sprints e responsabilidades
-11. Diretrizes finais
+10. Fluxo de branches e Boas Praticas (Git)
+11. Sprints e responsabilidades
+12. **Arquitetura 1:N (Laudo → Análises)** ← REGRA CORE
+13. Diretrizes finais
 
 ---
 
@@ -141,8 +143,8 @@ Tema MUI ja esta implementado em [labas-web/src/theme/index.ts](labas-web/src/th
 - /dashboard (privada)
 - /laudos (privada)
 - /laudos/novo (staff)
-- /laudos/:nLab (privada)
-- /laudos/:nLab/editar (staff)
+- /laudos/:id (privada)
+- /laudos/:id/editar (staff)
 - /calibracao (staff)
 - /calibracao/nova (staff)
 - /entrada-lote (staff) — nome de tela: Operacao em Lote
@@ -217,7 +219,7 @@ Regras de ouro:
 
 ---
 
-## 10. Fluxo de branches e Boas Práticas (Git)
+## 10. Fluxo de Branches e Boas Práticas (Git)
 
 **A Regra de Ouro da Segurança:** NUNCA execute um comando de `merge` sem antes commitar o seu trabalho atual na sua branch. Commitar antes garante que o seu código fique salvo no histórico e não seja perdido caso dê algum conflito.
 
@@ -281,7 +283,7 @@ Em seguida, garanta que a palavra `node_modules/` está escrita dentro do seu ar
 
 ---
 
-## 11. Sprints e responsabilidades
+## 11. Sprints e Responsabilidades
 
 ### Gabriel — `feat/gabriel/foundation`
 
@@ -303,10 +305,31 @@ Em seguida, garanta que a palavra `node_modules/` está escrita dentro do seu ar
   - `src/types/cliente.ts` + `src/services/clienteService.ts`
   - `src/schemas/clienteSchemas.ts` + `src/hooks/useClientes.ts` + `src/hooks/useClienteForm.ts`
   - `src/pages/clientes/ClientesPage.tsx` + `src/pages/clientes/ClienteFormPage.tsx`
-- 🔲 Sprint 6: Pagina de laudos — lista completa + editar + excluir (staff) — branch `feat/gabriel/laudos-page`
-  - **Bloco 1 — Hook:** `src/hooks/useLaudos.ts` — refatorar para suportar listagem completa (staff ve todos, cliente ve os seus), paginacao, delete com confirmacao
-  - **Bloco 2 — UI:** `src/pages/laudos/LaudosPage.tsx` — tabela MUI DataGrid com acoes (ver PDF, editar, excluir); botao "Novo Laudo" para staff; filtro por n_lab/cliente
-  - **Bloco 3 — Edicao:** `src/pages/laudos/LaudoEditPage.tsx` — rota `/laudos/:nLab/editar` (staff only); reusa `LaudoFormPage` com dados pre-carregados via `laudoService.buscar()`
+- ✅ Sprint 6: Página de laudos — lista completa + editar + excluir (staff) — branch `feat/gabriel/laudos-page`
+  - `src/hooks/useLaudos.ts` — refatorado: `Laudo[]`, `id: number`, `baixarPdf(id, codigoLaudo)`, `excluir(id)`, filtro por `codigo_laudo`/cliente
+  - `src/pages/laudos/LaudosPage.tsx` — tabela MUI com colunas: Código, Cliente, Data Emissão; ações: ver detalhe, PDF, editar, excluir (staff); campo de busca; `ConfirmDialog`
+  - `src/pages/laudos/LaudoFormPage.tsx` — formulário de criação cabeçalho only: Cliente (Autocomplete), `data_emissao`, `observacoes`
+  - `src/pages/laudos/LaudoEditPage.tsx` — rota `/laudos/:id/editar` (staff); form do cabeçalho + DataGrid de análises (toggle ativo, remover); `useParams<{ id: string }>()`
+- ✅ **Sprint 7 — Refatoração 1:N (Laudo → N Análises)** — branch `feat/gabriel/laudo-multi-analise`
+  - **Bloco 0 — Backend:** migração Django — `AnaliseSolo` recebe ForeignKey `laudo` (NOT NULL, cascade); serializers aninhados; endpoints `/laudos/:id/analises/`; PDF WeasyPrint itera `laudo.analises.filter(ativo=True)`
+  - **Bloco 1 — Tipos e Services:** `src/types/analise.ts` (`Laudo` + `AnaliseSolo` com `laudo_id`); `src/services/analiseService.ts` (listar, criar, atualizar, remover, toggleAtivo); `src/services/laudoService.ts` com `id: number`
+  - **Bloco 2 — Hooks e Schemas:** `src/schemas/analiseSchemas.ts`; `src/hooks/useAnalises.ts` (por `laudoId`); `src/hooks/useLaudoForm.ts` e `useLaudoEditForm.ts` atualizados para `Laudo`
+  - **Bloco 3 — UI:** `src/pages/laudos/LaudoDetalhePage.tsx` (rota `/laudos/:id`, read-only: cabeçalho + DataGrid + botão PDF); `src/App.tsx` (rotas com `:id`, lazy import `LaudoDetalhePage`)
+- ✅ **Sprint 8 — Roteiro de Execução + Correção de Análises** — branch `feat/gabriel/laudo-multi-analise`
+  - **`Laudo.data_saida`:** novo campo nullable `DateField` (migration `0019`); `data_emissao` relabelado para "Data de Entrada" na UI; `data_saida` ("Data de Saída") exposto em `LaudoEditPage`
+  - **Fluxo de criação:** após `POST /laudos/`, frontend redireciona para `/laudos/:id/editar` (hook `useLaudoForm`)
+  - **Sidebar:** item "Amostras" com `BiotechIcon` → `/entrada-lote`; botão "Ir para Amostras" no header de `LaudoEditPage`
+  - **`useAnalises`:** adicionados `editando: number | null` e `editar(analiseId, payload)` → `PATCH /laudos/:id/analises/:id/`; `pagination_class = None` em `AnaliseSoloListCreateView` (fix spread error)
+  - **Dialog Editar Ficha** (inline em `LaudoEditPage`): corrige `n_lab`, `referencia`, `data_entrada` via ícone `EditIcon`
+  - **`DialogCorrecaoAnalise`** — `src/components/shared/DialogCorrecaoAnalise.tsx`:
+    - Aba **Correção de Bancada**: lista leituras brutas por elemento; inputs de `leitura_bruta` + `fator_diluicao` (AA/FC/ES); PATCH em `/leituras/:id/` → signal re-dispara → recalcula SB/CTC/V%/m%; aviso informativo sobre recálculo automático
+    - Aba **Granulometria**: inputs areia, argila, silte com validação soma ≤ 100%; PATCH direto em `AnaliseSolo`
+    - Acionado pelo ícone `ScienceIcon` (cor `secondary`) na coluna de ações do DataGrid de amostras
+  - **Backend — novos endpoints:**
+    - `GET /api/analises/:id/leituras/` → `LeiturasPorAnaliseListView` (sem paginação)
+    - `GET|PATCH /api/leituras/:id/` → `LeituraEquipamentoDetailView`
+    - `LeituraEquipamentoDetalheSerializer`: expõe `elemento`, `elemento_display`, `equipamento`, `resultado_calculado`
+  - **Novos arquivos frontend:** `src/types/analise.ts` (`LeituraDetalhe`, `LeituraCorrecaoPayload`); `src/services/correcaoService.ts`; `src/hooks/useCorrecaoAnalise.ts`; `src/services/analiseService.ts` + método `buscar(laudoId, analiseId)`
 
 ### Sabrina — `feat/sabrina/laudos`
 
@@ -320,7 +343,57 @@ Zonas sem conflito:
 
 ---
 
-## 12. Diretrizes finais
+## 12. Arquitetura 1:N (Laudo → Análises)
+
+> **REGRA CORE — não violar.** Qualquer feature nova deve respeitar este contrato.
+
+### Princípio Fundamental
+
+**Laudo é o pai. AnaliseSolo é o filho. O PDF deve iterar sobre a coleção de análises.**
+
+### Contratos de Entidade
+
+| Entidade      | Papel                                             | Cardinalidade     |
+| ------------- | ------------------------------------------------- | ----------------- |
+| `Laudo`       | Cabeçalho do serviço — Cliente, Data, Observações | 1 (pai)           |
+| `AnaliseSolo` | Amostra individual com N_Lab único                | N (filho, max 50) |
+
+### Regras de Negócio
+
+- **ForeignKey obrigatória:** `AnaliseSolo.laudo` é NOT NULL. Proibido criar `AnaliseSolo` sem `Laudo` pai.
+- **Integridade referencial:** Ao deletar um `Laudo`, suas `AnaliseSolo` são removidas em cascata (`on_delete=CASCADE`).
+- **N_Lab único por laudo:** `unique_together = ['laudo', 'n_lab']` — a unicidade de `n_lab` é validada no escopo do laudo pai, não globalmente.
+- **codigo_laudo:** padrão `L-AAAA/N` (ex: `L-2026/1`), gerado automaticamente pelo backend via auto-increment por ano. O campo é read-only após criação.
+- **Campo `ativo` em AnaliseSolo:** `ativo = BooleanField(default=True)`. Análises com `ativo=False` são excluídas do PDF e do DataGrid de detalhe do laudo. Somente staff pode alternar o flag.
+- **PDF paginado:** O motor WeasyPrint itera `laudo.analises.filter(ativo=True)`. Limite de 50 análises ativas por laudo, com quebra de página a cada 5 (ou conforme layout do template).
+- **Campos calculados (SB, CTC, V%, m%):** Somente leitura na UI — nunca expor input para esses campos.
+- **Estratégia de migration:** Os registros legados de `AnaliseSolo` (sem laudo) recebem um `Laudo` stub gerado por cliente durante a migration — um laudo stub por cliente, agrupando todas as suas análises existentes.
+
+### Contrato de API
+
+```
+GET    /laudos/                        # lista de laudos (cabeçalhos)
+POST   /laudos/                        # cria laudo
+GET    /laudos/:id/                    # detalhe do laudo
+PUT    /laudos/:id/                    # edita laudo
+DELETE /laudos/:id/                    # remove laudo + análises (cascade)
+GET    /laudos/:id/analises/           # lista análises do laudo
+POST   /laudos/:id/analises/           # adiciona análise ao laudo
+GET    /laudos/:id/analises/:nLab/     # detalhe de uma análise
+PUT    /laudos/:id/analises/:nLab/     # edita análise
+DELETE /laudos/:id/analises/:nLab/     # remove análise
+GET    /laudos/:id/pdf/                # PDF com todas as análises paginadas
+```
+
+### Regras de UI
+
+- A tela de detalhe do laudo (`LaudoDetalhePage`) exibe o cabeçalho + DataGrid de análises.
+- O DataGrid de análises **não possui campos de digitação de leitura bruta** — isso acontece na Operação em Lote (`/entrada-lote`).
+- Botão "Gerar PDF" chama `/laudos/:id/pdf/` e faz download do documento único com todas as análises.
+
+---
+
+## 13. Diretrizes finais
 
 - Entregas complexas devem ser divididas em blocos:
   1. Tipos e services

--- a/backend/src/infrastructure/database/admin.py
+++ b/backend/src/infrastructure/database/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from .models import (
     Cliente,
+    Laudo,
     AnaliseSolo,
     BateriaCalibracao,
     LeituraEquipamento,
@@ -14,12 +15,15 @@ from .models import (
 
 @admin.register(Cliente)
 class ClienteAdmin(admin.ModelAdmin):
-    """
-    Interface de administracao para a entidade Cliente.
-    """
-
     list_display = ("codigo", "nome", "municipio", "contato")
     search_fields = ("nome", "codigo")
+
+
+@admin.register(Laudo)
+class LaudoAdmin(admin.ModelAdmin):
+    list_display = ("codigo_laudo", "cliente", "data_emissao")
+    search_fields = ("codigo_laudo", "cliente__nome", "cliente__codigo")
+    readonly_fields = ("codigo_laudo",)
 
 
 class LeituraEquipamentoLaudoInline(admin.TabularInline):
@@ -35,20 +39,20 @@ class LeituraEquipamentoLaudoInline(admin.TabularInline):
 
 @admin.register(AnaliseSolo)
 class AnaliseSoloAdmin(admin.ModelAdmin):
-    """
-    Painel central do sistema: O Laudo de Analise de Solo.
-    Organiza os inumeros atributos quimicos e fisicos em blocos logicos expansivos,
-    espelhando as planilhas oficiais do laboratorio.
-    """
-
-    list_display = ("n_lab", "cliente", "data_entrada", "ph_agua", "p_m")
-    search_fields = ("n_lab", "cliente__nome")
+    list_display = ("n_lab", "laudo", "ativo", "data_entrada", "ph_agua", "p_m")
+    search_fields = ("n_lab", "laudo__cliente__nome", "laudo__codigo_laudo")
+    list_filter = ("ativo",)
     inlines = [LeituraEquipamentoLaudoInline]
 
     fieldsets = (
         (
             "1. Identificacao e Controle",
-            {"fields": (("n_lab", "cliente"), ("data_entrada", "data_saida"))},
+            {
+                "fields": (
+                    ("n_lab", "laudo", "ativo", "referencia"),
+                    ("data_entrada", "data_saida"),
+                )
+            },
         ),
         ("2. Phagametro (Acidez)", {"fields": (("ph_agua", "ph_cacl2", "ph_kcl"),)}),
         (

--- a/backend/src/infrastructure/database/migrations/0016_add_laudo_model.py
+++ b/backend/src/infrastructure/database/migrations/0016_add_laudo_model.py
@@ -1,0 +1,98 @@
+# Generated manually — Sprint 7: Refatoração 1:N (Laudo → N Análises)
+# Passo 1/3: Cria model Laudo e adiciona campos nullable em AnaliseSolo.
+
+import django.db.models.deletion
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("database", "0015_alter_analisesolo_options_and_more"),
+    ]
+
+    operations = [
+        # 1. Cria o model Laudo (cabeçalho do documento)
+        migrations.CreateModel(
+            name="Laudo",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "codigo_laudo",
+                    models.CharField(
+                        editable=False,
+                        max_length=20,
+                        unique=True,
+                        verbose_name="Código do Laudo",
+                    ),
+                ),
+                (
+                    "data_emissao",
+                    models.DateField(
+                        default=django.utils.timezone.now,
+                        verbose_name="Data de Emissão",
+                    ),
+                ),
+                (
+                    "observacoes",
+                    models.TextField(blank=True, null=True, verbose_name="Observações"),
+                ),
+                (
+                    "cliente",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="laudos",
+                        to="database.cliente",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Laudo",
+                "verbose_name_plural": "Laudos",
+            },
+        ),
+        # 2. Adiciona FK nullable laudo em AnaliseSolo (nullable p/ migration de dados)
+        migrations.AddField(
+            model_name="analisesolo",
+            name="laudo",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="analises",
+                to="database.laudo",
+            ),
+        ),
+        # 3. Adiciona campo ativo
+        migrations.AddField(
+            model_name="analisesolo",
+            name="ativo",
+            field=models.BooleanField(default=True, verbose_name="Ativo"),
+        ),
+        # 4. Adiciona campo referencia (coluna exibida no PDF)
+        migrations.AddField(
+            model_name="analisesolo",
+            name="referencia",
+            field=models.CharField(
+                blank=True,
+                max_length=100,
+                null=True,
+                verbose_name="Referência Cliente",
+            ),
+        ),
+        # 5. Remove unique=True do n_lab (unicidade agora é por laudo via unique_together)
+        migrations.AlterField(
+            model_name="analisesolo",
+            name="n_lab",
+            field=models.CharField(max_length=50, verbose_name="N Lab"),
+        ),
+    ]

--- a/backend/src/infrastructure/database/migrations/0017_data_link_analises_laudos.py
+++ b/backend/src/infrastructure/database/migrations/0017_data_link_analises_laudos.py
@@ -1,0 +1,50 @@
+# Generated manually — Sprint 7: Refatoração 1:N (Laudo → N Análises)
+# Passo 2/3: Data migration — cria Laudos stub por cliente e vincula AnaliseSolo.
+
+from datetime import date
+
+from django.db import migrations
+
+
+def criar_laudos_stub(apps, schema_editor):
+    """
+    Para cada Cliente que possui AnaliseSolo, cria um único Laudo stub
+    e vincula todas as suas análises a esse laudo.
+    """
+    AnaliseSolo = apps.get_model("database", "AnaliseSolo")
+    Laudo = apps.get_model("database", "Laudo")
+
+    ano = date.today().year
+    cliente_ids = (
+        AnaliseSolo.objects.values_list("cliente_id", flat=True)
+        .distinct()
+        .order_by("cliente_id")
+    )
+
+    for cliente_id in cliente_ids:
+        count = Laudo.objects.filter(codigo_laudo__startswith=f"L-{ano}/").count()
+        laudo = Laudo.objects.create(
+            codigo_laudo=f"L-{ano}/{count + 1}",
+            cliente_id=cliente_id,
+            data_emissao=date.today(),
+        )
+        AnaliseSolo.objects.filter(cliente_id=cliente_id).update(laudo=laudo)
+
+
+def desfazer_laudos_stub(apps, schema_editor):
+    """Reverte: desvincula AnaliseSolo e remove laudos stub."""
+    AnaliseSolo = apps.get_model("database", "AnaliseSolo")
+    Laudo = apps.get_model("database", "Laudo")
+    AnaliseSolo.objects.all().update(laudo=None)
+    Laudo.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("database", "0016_add_laudo_model"),
+    ]
+
+    operations = [
+        migrations.RunPython(criar_laudos_stub, desfazer_laudos_stub),
+    ]

--- a/backend/src/infrastructure/database/migrations/0018_finalize_laudo_fk.py
+++ b/backend/src/infrastructure/database/migrations/0018_finalize_laudo_fk.py
@@ -1,0 +1,43 @@
+# Generated manually — Sprint 7: Refatoração 1:N (Laudo → N Análises)
+# Passo 3/3: Torna laudo NOT NULL, remove cliente FK, adiciona unique_together.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("database", "0017_data_link_analises_laudos"),
+    ]
+
+    operations = [
+        # 1. Torna laudo FK NOT NULL (todos os registros já foram vinculados em 0017)
+        migrations.AlterField(
+            model_name="analisesolo",
+            name="laudo",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="analises",
+                to="database.laudo",
+            ),
+        ),
+        # 2. Remove FK cliente de AnaliseSolo (cliente agora está em Laudo)
+        migrations.RemoveField(
+            model_name="analisesolo",
+            name="cliente",
+        ),
+        # 3. Aplica unicidade de n_lab no escopo do laudo
+        migrations.AlterUniqueTogether(
+            name="analisesolo",
+            unique_together={("laudo", "n_lab")},
+        ),
+        # 4. Atualiza verbose_name do model
+        migrations.AlterModelOptions(
+            name="analisesolo",
+            options={
+                "verbose_name": "Analise de Solo",
+                "verbose_name_plural": "Analises de Solo",
+            },
+        ),
+    ]

--- a/backend/src/infrastructure/database/migrations/0019_laudo_data_saida.py
+++ b/backend/src/infrastructure/database/migrations/0019_laudo_data_saida.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("database", "0018_finalize_laudo_fk"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="laudo",
+            name="data_saida",
+            field=models.DateField(blank=True, null=True, verbose_name="Data de Saída"),
+        ),
+        migrations.AlterField(
+            model_name="laudo",
+            name="data_emissao",
+            field=models.DateField(
+                auto_now_add=False,
+                verbose_name="Data de Entrada",
+            ),
+        ),
+    ]

--- a/backend/src/infrastructure/database/models.py
+++ b/backend/src/infrastructure/database/models.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
@@ -33,15 +33,59 @@ class Cliente(models.Model):
         verbose_name_plural = "Clientes"
 
 
+class Laudo(models.Model):
+    """
+    Cabeçalho do documento entregue ao cliente.
+    Agrupa N análises de solo (AnaliseSolo) em um único laudo.
+    O código é gerado automaticamente no formato L-AAAA/N.
+    """
+
+    codigo_laudo = models.CharField(
+        max_length=20,
+        unique=True,
+        editable=False,
+        verbose_name="Código do Laudo",
+    )
+    cliente = models.ForeignKey(
+        Cliente, on_delete=models.CASCADE, related_name="laudos"
+    )
+    data_emissao = models.DateField(
+        default=timezone.now, verbose_name="Data de Entrada"
+    )
+    data_saida = models.DateField(blank=True, null=True, verbose_name="Data de Saída")
+    observacoes = models.TextField(blank=True, null=True, verbose_name="Observações")
+
+    def save(self, *args, **kwargs):
+        if not self.codigo_laudo:
+            with transaction.atomic():
+                ano = timezone.now().year
+                count = (
+                    Laudo.objects.filter(codigo_laudo__startswith=f"L-{ano}/")
+                    .select_for_update()
+                    .count()
+                )
+                self.codigo_laudo = f"L-{ano}/{count + 1}"
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"{self.codigo_laudo} — {self.cliente.nome}"
+
+    class Meta:
+        verbose_name = "Laudo"
+        verbose_name_plural = "Laudos"
+
+
 class AnaliseSolo(models.Model):
     """
-    Entidade central do sistema (O Laudo).
+    Amostra individual de solo. Filho de Laudo (N análises por laudo, máx 50).
     Atributos agora possuem default=0 para evitar erros matematicos e nulos na API.
     """
 
-    n_lab = models.CharField(max_length=50, unique=True, verbose_name="N Lab")
-    cliente = models.ForeignKey(
-        Cliente, on_delete=models.CASCADE, related_name="analises"
+    n_lab = models.CharField(max_length=50, verbose_name="N Lab")
+    laudo = models.ForeignKey(Laudo, on_delete=models.CASCADE, related_name="analises")
+    ativo = models.BooleanField(default=True, verbose_name="Ativo")
+    referencia = models.CharField(
+        max_length=100, blank=True, null=True, verbose_name="Referência Cliente"
     )
     data_entrada = models.DateField(default=timezone.now, verbose_name="Data Entrada")
     data_saida = models.DateField(blank=True, null=True, verbose_name="Data Saida")
@@ -314,11 +358,12 @@ class AnaliseSolo(models.Model):
             raise ValidationError({"ph_agua": "O pH deve estar entre 0 e 14."})
 
     def __str__(self):
-        return f"Laudo {self.n_lab} - {self.cliente.nome}"
+        return f"Análise {self.n_lab} — Laudo {self.laudo.codigo_laudo}"
 
     class Meta:
         verbose_name = "Analise de Solo"
         verbose_name_plural = "Analises de Solo"
+        unique_together = [("laudo", "n_lab")]
 
 
 class BateriaCalibracao(models.Model):

--- a/backend/src/infrastructure/web/serializers.py
+++ b/backend/src/infrastructure/web/serializers.py
@@ -1,10 +1,10 @@
 from rest_framework import serializers
-from rest_framework.validators import UniqueValidator
 from django.core.validators import RegexValidator
 from django.contrib.auth.models import User
 from django.db import transaction, IntegrityError
 from src.infrastructure.database.models import (
     Cliente,
+    Laudo,
     AnaliseSolo,
     BateriaCalibracao,
     LeituraEquipamento,
@@ -81,6 +81,54 @@ class ClienteSerializer(serializers.ModelSerializer):
         fields = ["codigo", "nome", "municipio", "area"]
 
 
+class LaudoSerializer(serializers.ModelSerializer):
+    """
+    Serializer do cabeçalho do laudo.
+    Leitura: retorna objeto cliente aninhado.
+    Escrita: recebe cliente_codigo para resolucao.
+    """
+
+    cliente = ClienteSerializer(read_only=True)
+    cliente_codigo = serializers.CharField(write_only=True, required=True)
+
+    def create(self, validated_data):
+        cliente_codigo = validated_data.pop("cliente_codigo")
+        try:
+            cliente = Cliente.objects.get(codigo=cliente_codigo)
+        except Cliente.DoesNotExist:
+            raise serializers.ValidationError(
+                {"cliente_codigo": "Cliente nao encontrado com este codigo."}
+            )
+        return Laudo.objects.create(cliente=cliente, **validated_data)
+
+    def update(self, instance, validated_data):
+        cliente_codigo = validated_data.pop("cliente_codigo", None)
+        if cliente_codigo:
+            try:
+                instance.cliente = Cliente.objects.get(codigo=cliente_codigo)
+            except Cliente.DoesNotExist:
+                raise serializers.ValidationError(
+                    {"cliente_codigo": "Cliente nao encontrado com este codigo."}
+                )
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+        return instance
+
+    class Meta:
+        model = Laudo
+        fields = [
+            "id",
+            "codigo_laudo",
+            "cliente_codigo",
+            "cliente",
+            "data_emissao",
+            "data_saida",
+            "observacoes",
+        ]
+        read_only_fields = ["id", "codigo_laudo"]
+
+
 class ClienteCadastroSerializer(serializers.ModelSerializer):
     """
     CRUD de clientes pelo staff.
@@ -104,61 +152,44 @@ class ClienteCadastroSerializer(serializers.ModelSerializer):
 # Serializer principal para os resultados das analises quimicas
 class AnaliseSoloSerializer(serializers.ModelSerializer):
     """
-    Centraliza a logica de transformacao dos resultados laboratoriais
-    Aplica as validacoes tecnicas necessarias para o padrao UFU
+    Centraliza a logica de transformacao dos resultados laboratoriais.
+    Analise e sempre filha de um Laudo — laudo_id e inferido pelo contexto da view.
     """
 
-    # Inclui os dados do cliente de forma aninhada apenas para leitura
-    cliente = ClienteSerializer(read_only=True)
+    laudo_id = serializers.IntegerField(read_only=True)
 
-    # Campo de escrita: recebe o codigo do cliente para resolucao no create()
-    cliente_codigo = serializers.CharField(write_only=True, required=True)
-
-    # Aplica regra de formato e unicidade para o identificador do laboratorio
+    # Mantém validacao de formato mas unicidade é por laudo (validada em validate())
     n_lab = serializers.CharField(
         validators=[
             RegexValidator(
                 regex=r"^\d{4}/.+$",
                 message="O padrao do N Lab deve ser ANO/NUMERO ex 2026/001",
             ),
-            UniqueValidator(
-                queryset=AnaliseSolo.objects.all(),
-                message="Ja existe um laudo registrado com este N Lab.",
-            ),
         ]
     )
 
-    def create(self, validated_data):
-        cliente_codigo = validated_data.pop("cliente_codigo")
-        try:
-            cliente = Cliente.objects.get(codigo=cliente_codigo)
-        except Cliente.DoesNotExist:
-            raise serializers.ValidationError(
-                {"cliente_codigo": "Cliente nao encontrado com este codigo."}
-            )
-        return AnaliseSolo.objects.create(cliente=cliente, **validated_data)
-
-    def update(self, instance, validated_data):
-        cliente_codigo = validated_data.pop("cliente_codigo", None)
-        if cliente_codigo:
-            try:
-                instance.cliente = Cliente.objects.get(codigo=cliente_codigo)
-            except Cliente.DoesNotExist:
+    def validate(self, data):
+        """Valida unicidade de n_lab no escopo do laudo pai."""
+        laudo = self.context.get("laudo")
+        n_lab = data.get("n_lab", getattr(self.instance, "n_lab", None))
+        if laudo and n_lab:
+            qs = AnaliseSolo.objects.filter(laudo=laudo, n_lab=n_lab)
+            if self.instance:
+                qs = qs.exclude(pk=self.instance.pk)
+            if qs.exists():
                 raise serializers.ValidationError(
-                    {"cliente_codigo": "Cliente nao encontrado com este codigo."}
+                    {"n_lab": "Já existe uma análise com este N Lab neste laudo."}
                 )
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
-        instance.save()
-        return instance
+        return data
 
     class Meta:
         model = AnaliseSolo
-        # Mapeia todos os atributos quimicos e fisicos para o formato JSON
         fields = [
+            "id",
+            "laudo_id",
             "n_lab",
-            "cliente_codigo",
-            "cliente",
+            "ativo",
+            "referencia",
             "data_entrada",
             "data_saida",
             "ph_agua",
@@ -183,6 +214,19 @@ class AnaliseSoloSerializer(serializers.ModelSerializer):
             "areia",
             "argila",
             "silte",
+            "sb",
+            "t",
+            "T_maiusculo",
+            "V",
+            "m",
+            "ca_mg",
+            "ca_k",
+            "mg_k",
+            "c_org",
+        ]
+        read_only_fields = [
+            "id",
+            "laudo_id",
             "sb",
             "t",
             "T_maiusculo",
@@ -265,7 +309,7 @@ class AmostraPendenteSerializer(serializers.ModelSerializer):
     Expoe apenas os campos necessarios para identificar a amostra na bancada.
     """
 
-    cliente_nome = serializers.CharField(source="cliente.nome", read_only=True)
+    cliente_nome = serializers.CharField(source="laudo.cliente.nome", read_only=True)
 
     class Meta:
         model = AnaliseSolo
@@ -289,3 +333,44 @@ class LeituraEquipamentoSerializer(serializers.ModelSerializer):
         instance = LeituraEquipamento(**attrs)
         instance.clean()
         return attrs
+
+
+class LeituraEquipamentoDetalheSerializer(serializers.ModelSerializer):
+    """
+    Serializer de leitura para visualizacao e correcao.
+    Expoe elemento e equipamento da bateria para o frontend poder
+    rotular cada linha sem precisar de chamadas adicionais.
+    """
+
+    elemento = serializers.CharField(source="bateria.elemento", read_only=True)
+    elemento_display = serializers.CharField(
+        source="bateria.get_elemento_display", read_only=True
+    )
+    equipamento = serializers.CharField(source="bateria.equipamento", read_only=True)
+    resultado_calculado = serializers.SerializerMethodField()
+
+    class Meta:
+        model = LeituraEquipamento
+        fields = [
+            "id",
+            "bateria",
+            "elemento",
+            "elemento_display",
+            "equipamento",
+            "leitura_bruta",
+            "fator_diluicao",
+            "resultado_calculado",
+        ]
+        read_only_fields = [
+            "id",
+            "bateria",
+            "elemento",
+            "elemento_display",
+            "equipamento",
+            "resultado_calculado",
+        ]
+
+    def get_resultado_calculado(self, obj):
+        campo = obj.bateria.elemento.lower()
+        valor = getattr(obj.analise, campo, None)
+        return float(valor) if valor is not None else None

--- a/backend/src/infrastructure/web/urls.py
+++ b/backend/src/infrastructure/web/urls.py
@@ -17,14 +17,20 @@ urlpatterns = [
     path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("me/", views.MeView.as_view(), name="me"),
     # ---------------------------------------------------------
-    # 2 GESTAO DE LAUDOS RECURSOS PROTEGIDOS
+    # 2 GESTAO DE LAUDOS — arquitetura 1:N
     # ---------------------------------------------------------
-    path("meus-laudos/<path:n_lab>/pdf/", views.gerar_laudo_pdf, name="laudo_pdf"),
-    path("meus-laudos/", views.MeusLaudosAPIView.as_view(), name="listar_criar_laudos"),
+    path("laudos/", views.LaudoListCreateView.as_view(), name="laudo_list_create"),
+    path("laudos/<int:pk>/", views.LaudoDetailView.as_view(), name="laudo_detail"),
+    path("laudos/<int:pk>/pdf/", views.gerar_laudo_pdf, name="laudo_pdf"),
     path(
-        "meus-laudos/<path:n_lab>/",
-        views.LaudoDetailAPIView.as_view(),
-        name="laudo_detalhe",
+        "laudos/<int:laudo_pk>/analises/",
+        views.AnaliseSoloListCreateView.as_view(),
+        name="analise_list_create",
+    ),
+    path(
+        "laudos/<int:laudo_pk>/analises/<int:pk>/",
+        views.AnaliseSoloDetailView.as_view(),
+        name="analise_detail",
     ),
     # ---------------------------------------------------------
     # 3 CALIBRACAO DE EQUIPAMENTOS (staff only)
@@ -61,6 +67,16 @@ urlpatterns = [
         "leituras/",
         views.LeituraEquipamentoCreateView.as_view(),
         name="leitura_create",
+    ),
+    path(
+        "leituras/<int:pk>/",
+        views.LeituraEquipamentoDetailView.as_view(),
+        name="leitura_detail",
+    ),
+    path(
+        "analises/<int:analise_id>/leituras/",
+        views.LeiturasPorAnaliseListView.as_view(),
+        name="leituras_por_analise",
     ),
     # ---------------------------------------------------------
     # 5 GESTAO DE CLIENTES (staff only)

--- a/backend/src/infrastructure/web/views.py
+++ b/backend/src/infrastructure/web/views.py
@@ -18,18 +18,21 @@ from src.infrastructure.database.models import (
     AnaliseSolo,
     BateriaCalibracao,
     Cliente,
+    Laudo,
     LeituraEquipamento,
     PontoCalibracao,
 )
 from .serializers import (
     AnaliseSoloSerializer,
     ClienteCadastroSerializer,
+    LaudoSerializer,
     UserRegistrationSerializer,
     BateriaCalibracaoSerializer,
     BateriaCalibracaoAtivoSerializer,
     PontoCalibracaoSerializer,
     AmostraPendenteSerializer,
     LeituraEquipamentoSerializer,
+    LeituraEquipamentoDetalheSerializer,
 )
 from .permissions import IsOwnerOrTechnician
 
@@ -81,53 +84,101 @@ class MeView(APIView):
 
 
 # =============================================================================
-# 2 GESTAO DE LAUDOS PROTEGIDO
+# 2 GESTAO DE LAUDOS — arquitetura 1:N (Laudo -> N AnaliseSolo)
 # =============================================================================
 
 
-# Controlador para colecoes de laudos com regras de visibilidade
-class MeusLaudosAPIView(generics.ListCreateAPIView):
+class LaudoListCreateView(generics.ListCreateAPIView):
     """
-    Gerencia a listagem e submissao de analises
-    Aplica filtros de seguranca baseados no tipo de conta
+    GET  /api/laudos/   -> staff: todos os laudos | cliente: apenas os seus
+    POST /api/laudos/   -> cria laudo (staff only — validado em IsOwnerOrTechnician)
     """
 
-    serializer_class = AnaliseSoloSerializer
+    serializer_class = LaudoSerializer
     permission_classes = [IsAuthenticated, IsOwnerOrTechnician]
 
     def get_queryset(self):
-        # Implementa o isolamento de dados entre clientes e equipe tecnica
         user = self.request.user
         if user.is_anonymous:
-            return AnaliseSolo.objects.none()
-
-        # Tecnicos visualizam o historico completo do laboratorio
+            return Laudo.objects.none()
         if user.is_staff:
-            return AnaliseSolo.objects.all().order_by("-data_entrada")
-
-        # Clientes restritos aos laudos vinculados ao seu proprio perfil
-        return AnaliseSolo.objects.filter(cliente__usuario=user).order_by(
-            "-data_entrada"
+            return Laudo.objects.select_related("cliente").order_by("-data_emissao")
+        return (
+            Laudo.objects.select_related("cliente")
+            .filter(cliente__usuario=user)
+            .order_by("-data_emissao")
         )
 
 
-# Controlador para manipulacao de um registro individual
-class LaudoDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
+class LaudoDetailView(generics.RetrieveUpdateDestroyAPIView):
     """
-    Interface para consulta detalhada edicao e exclusao
-    Utiliza o identificador textual n_lab para facilitar a busca
+    GET    /api/laudos/<pk>/  -> detalhe do laudo
+    PUT    /api/laudos/<pk>/  -> edita cabeçalho (staff only)
+    DELETE /api/laudos/<pk>/  -> remove laudo + analises em cascade (staff only)
+    """
+
+    serializer_class = LaudoSerializer
+    permission_classes = [IsAuthenticated, IsOwnerOrTechnician]
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_staff:
+            return Laudo.objects.select_related("cliente").all()
+        return Laudo.objects.select_related("cliente").filter(cliente__usuario=user)
+
+
+class AnaliseSoloListCreateView(generics.ListCreateAPIView):
+    """
+    GET  /api/laudos/<laudo_pk>/analises/  -> lista analises ativas do laudo
+    POST /api/laudos/<laudo_pk>/analises/  -> adiciona analise ao laudo (staff only)
     """
 
     serializer_class = AnaliseSoloSerializer
     permission_classes = [IsAuthenticated, IsOwnerOrTechnician]
-    lookup_field = "n_lab"
+    pagination_class = None  # análises são sempre do escopo de um laudo (máx. 50)
+
+    def _get_laudo(self):
+        laudo = get_object_or_404(Laudo, pk=self.kwargs["laudo_pk"])
+        self.check_object_permissions(self.request, laudo)
+        return laudo
 
     def get_queryset(self):
-        # Garante que a busca individual respeite as travas de seguranca
-        user = self.request.user
-        if user.is_staff:
-            return AnaliseSolo.objects.all()
-        return AnaliseSolo.objects.filter(cliente__usuario=user)
+        laudo = self._get_laudo()
+        return AnaliseSolo.objects.filter(laudo=laudo, ativo=True).order_by("n_lab")
+
+    def get_serializer_context(self):
+        ctx = super().get_serializer_context()
+        ctx["laudo"] = self._get_laudo()
+        return ctx
+
+    def perform_create(self, serializer):
+        laudo = self._get_laudo()
+        serializer.save(laudo=laudo)
+
+
+class AnaliseSoloDetailView(generics.RetrieveUpdateDestroyAPIView):
+    """
+    GET    /api/laudos/<laudo_pk>/analises/<pk>/  -> detalhe da analise
+    PUT    /api/laudos/<laudo_pk>/analises/<pk>/  -> edita analise (staff only)
+    DELETE /api/laudos/<laudo_pk>/analises/<pk>/  -> remove analise (staff only)
+    """
+
+    serializer_class = AnaliseSoloSerializer
+    permission_classes = [IsAuthenticated, IsOwnerOrTechnician]
+
+    def _get_laudo(self):
+        laudo = get_object_or_404(Laudo, pk=self.kwargs["laudo_pk"])
+        self.check_object_permissions(self.request, laudo)
+        return laudo
+
+    def get_queryset(self):
+        laudo = self._get_laudo()
+        return AnaliseSolo.objects.filter(laudo=laudo)
+
+    def get_serializer_context(self):
+        ctx = super().get_serializer_context()
+        ctx["laudo"] = self._get_laudo()
+        return ctx
 
 
 # =============================================================================
@@ -135,48 +186,36 @@ class LaudoDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
 # =============================================================================
 
 
-# Ponto de extremidade para extracao de relatorio oficial formatado
 @api_view(["GET"])
 @authentication_classes([SessionAuthentication, JWTAuthentication])
 @permission_classes([IsAuthenticated])
-def gerar_laudo_pdf(request, n_lab):
-    # Trata o identificador recebido
-    n_lab_limpo = n_lab.strip("/")
-    laudo_foco = get_object_or_404(AnaliseSolo, n_lab=n_lab_limpo)
+def gerar_laudo_pdf(request, pk):
+    laudo = get_object_or_404(Laudo.objects.select_related("cliente__usuario"), pk=pk)
 
-    # Validacao de seguranca para acesso ao laudo
-    if not (request.user.is_staff or laudo_foco.cliente.usuario == request.user):
+    if not (request.user.is_staff or laudo.cliente.usuario == request.user):
         return Response(
-            {"detail": "Acesso negado Este laudo nao pertence a voce"},
+            {"detail": "Acesso negado. Este laudo nao pertence a voce."},
             status=status.HTTP_403_FORBIDDEN,
         )
 
-    # Coleta as analises do banco de dados limitado a cinco registros
-    analises_reais = list(
-        AnaliseSolo.objects.filter(cliente=laudo_foco.cliente).order_by(
-            "-data_entrada"
-        )[:5]
-    )
-
-    # Injeta valores nulos para completar a lista de cinco posicoes para o layout
-    # Isso permite que o html identifique onde deve riscar a linha
-    analises_preparadas = analises_reais + [None] * (5 - len(analises_reais))
+    # Filtra apenas analises ativas, limit 50, divide em paginas de 5
+    analises_ativas = list(laudo.analises.filter(ativo=True).order_by("n_lab")[:50])
+    paginas = [
+        analises_ativas[i : i + 5] for i in range(0, max(len(analises_ativas), 1), 5)
+    ]
 
     context = {
-        "cliente": laudo_foco.cliente,
-        "analises": analises_preparadas,
-        "laudo_foco": laudo_foco,
+        "laudo": laudo,
+        "cliente": laudo.cliente,
+        "paginas": paginas,
     }
 
-    # Processamento do documento via motor WeasyPrint
     html_string = render_to_string("laudos/modelo_oficial.html", context)
     pdf = HTML(string=html_string, base_url=request.build_absolute_uri("/")).write_pdf()
 
-    # Configuracao do cabecalho de resposta do arquivo binario
+    nome_arquivo = f"laudo_{laudo.codigo_laudo.replace('/', '-')}.pdf"
     response = HttpResponse(pdf, content_type="application/pdf")
-    nome_arquivo = f"relatorio_{laudo_foco.n_lab.replace('/', '-')}.pdf"
     response["Content-Disposition"] = f'inline; filename="{nome_arquivo}"'
-
     return response
 
 
@@ -322,7 +361,7 @@ class AmostrasPendentesListView(generics.ListAPIView):
         ).values_list("analise_id", flat=True)
 
         return (
-            AnaliseSolo.objects.select_related("cliente")
+            AnaliseSolo.objects.select_related("laudo__cliente")
             .exclude(id__in=ids_com_leitura)
             .order_by("n_lab")
         )
@@ -372,6 +411,79 @@ class LeituraEquipamentoCreateView(generics.CreateAPIView):
 
         headers = self.get_success_headers(serializer.data)
         return Response(data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class LeiturasPorAnaliseListView(generics.ListAPIView):
+    """
+    GET /api/analises/<analise_id>/leituras/
+    Lista todas as leituras brutas registradas para uma analise,
+    com o resultado calculado atual (lido diretamente da AnaliseSolo).
+    Usado pelo DialogCorrecaoAnalise para popular a aba de bancada.
+    """
+
+    serializer_class = LeituraEquipamentoDetalheSerializer
+    pagination_class = None
+
+    def get_permissions(self):
+        from rest_framework.permissions import IsAdminUser
+
+        return [IsAuthenticated(), IsAdminUser()]
+
+    def get_queryset(self):
+        analise = get_object_or_404(AnaliseSolo, pk=self.kwargs["analise_id"])
+        return (
+            LeituraEquipamento.objects.filter(analise=analise)
+            .select_related("bateria", "analise")
+            .order_by("bateria__elemento")
+        )
+
+
+class LeituraEquipamentoDetailView(generics.RetrieveUpdateAPIView):
+    """
+    GET   /api/leituras/<pk>/  -> detalhe da leitura (com resultado calculado)
+    PATCH /api/leituras/<pk>/  -> corrige leitura_bruta e/ou fator_diluicao.
+                                  O signal post_save re-dispara e recalcula
+                                  o campo correspondente na AnaliseSolo.
+    """
+
+    queryset = LeituraEquipamento.objects.select_related("bateria", "analise").all()
+    http_method_names = ["get", "patch"]
+
+    def get_permissions(self):
+        from rest_framework.permissions import IsAdminUser
+
+        return [IsAuthenticated(), IsAdminUser()]
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return LeituraEquipamentoDetalheSerializer
+        return LeituraEquipamentoSerializer
+
+    def update(self, request, *args, **kwargs):
+        kwargs["partial"] = True  # sempre PATCH
+        instance = self.get_object()
+
+        serializer = LeituraEquipamentoSerializer(
+            instance, data=request.data, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        leitura = serializer.save()  # signal re-dispara aqui
+
+        leitura.analise.refresh_from_db()
+        campo_elemento = leitura.bateria.elemento.lower()
+        valor_calculado = getattr(leitura.analise, campo_elemento, None)
+
+        resposta = LeituraEquipamentoDetalheSerializer(
+            leitura, context=self.get_serializer_context()
+        ).data
+        return Response(
+            {
+                **resposta,
+                "resultado_calculado": (
+                    float(valor_calculado) if valor_calculado is not None else None
+                ),
+            }
+        )
 
 
 # =============================================================================

--- a/backend/templates/laudos/modelo_oficial.html
+++ b/backend/templates/laudos/modelo_oficial.html
@@ -39,20 +39,17 @@
         <td class="label-cell">Solicitante:</td>
         <td style="width: 38%">{{ cliente.nome }}</td>
 
-        <td class="label-cell">Entrada:</td>
-        <td style="width: 12%">{{ laudo_foco.data_entrada|date:"d/m/Y" }}</td>
+        <td class="label-cell">N° Laudo:</td>
+        <td style="width: 12%">{{ laudo.codigo_laudo }}</td>
 
-        <td class="label-cell">Saída:</td>
-        <td style="width: 12%">
-          {{ laudo_foco.data_saida|date:"d/m/Y"|default:"-" }}
-        </td>
+        <td class="label-cell">Emissão:</td>
+        <td style="width: 12%">{{ laudo.data_emissao|date:"d/m/Y" }}</td>
       </tr>
 
       <tr>
         <td class="label-cell">Obs:</td>
         <td colspan="5">
-          {% if laudo_foco.observacoes %} {{ laudo_foco.observacoes }} {% else
-          %}
+          {% if laudo.observacoes %}{{ laudo.observacoes }}{% else %}
           ------------------------------------------------------------------------------------------------
           {% endif %}
         </td>
@@ -81,6 +78,8 @@
       RESULTADOS DE ANÁLISE QUÍMICA DE SOLO
     </div>
 
+    {% for pagina in paginas %}
+
     <!-- TABELA 1 -->
     <table class="results-table">
       <thead>
@@ -108,7 +107,7 @@
       </thead>
 
       <tbody>
-        {% for item in analises %} {% if item %}
+        {% for item in pagina %}
         <tr>
           <td>{{ item.n_lab }}</td>
           <td>{{ item.referencia|default:"-" }}</td>
@@ -123,11 +122,7 @@
           <td>{{ item.s }}</td>
           <td>{{ item.b }}</td>
         </tr>
-        {% else %}
-        <tr class="row-void">
-          <td colspan="12"></td>
-        </tr>
-        {% endif %} {% endfor %}
+        {% endfor %}
       </tbody>
     </table>
 
@@ -153,7 +148,7 @@
       </thead>
 
       <tbody>
-        {% for item in analises %} {% if item %}
+        {% for item in pagina %}
         <tr>
           <td>{{ item.n_lab }}</td>
           <td>{{ item.ca }}</td>
@@ -165,11 +160,7 @@
           <td>{{ item.mn }}</td>
           <td>{{ item.zn }}</td>
         </tr>
-        {% else %}
-        <tr class="row-void">
-          <td colspan="9"></td>
-        </tr>
-        {% endif %} {% endfor %}
+        {% endfor %}
       </tbody>
     </table>
 
@@ -199,7 +190,7 @@
       </thead>
 
       <tbody>
-        {% for item in analises %} {% if item %}
+        {% for item in pagina %}
         <tr>
           <td>{{ item.n_lab }}</td>
           <td>{{ item.sb }}</td>
@@ -213,13 +204,13 @@
           <td>{{ item.ca_k }}</td>
           <td>{{ item.mg_k }}</td>
         </tr>
-        {% else %}
-        <tr class="row-void">
-          <td colspan="11"></td>
-        </tr>
-        {% endif %} {% endfor %}
+        {% endfor %}
       </tbody>
     </table>
+
+    {% if not forloop.last %}
+    <div style="page-break-after: always"></div>
+    {% endif %} {% endfor %}
 
     <!-- RODAPÉ -->
     <div class="footer-section">

--- a/labas-web/src/App.tsx
+++ b/labas-web/src/App.tsx
@@ -21,6 +21,7 @@ const EntradaLotePage = lazy(
 );
 const LaudoFormPage = lazy(() => import("./pages/laudos/LaudoFormPage"));
 const LaudoEditPage = lazy(() => import("./pages/laudos/LaudoEditPage"));
+const LaudoDetalhePage = lazy(() => import("./pages/laudos/LaudoDetalhePage"));
 const LaudosPage = lazy(() => import("./pages/laudos/LaudosPage"));
 const ClientesPage = lazy(() => import("./pages/clientes/ClientesPage"));
 const ClienteFormPage = lazy(() => import("./pages/clientes/ClienteFormPage"));
@@ -54,6 +55,16 @@ export default function App() {
             <AppShell>
               <Suspense fallback={<Spinner />}>
                 <LaudosPage />
+              </Suspense>
+            </AppShell>
+          }
+        />
+        <Route
+          path="/laudos/:id"
+          element={
+            <AppShell>
+              <Suspense fallback={<Spinner />}>
+                <LaudoDetalhePage />
               </Suspense>
             </AppShell>
           }
@@ -113,7 +124,7 @@ export default function App() {
           }
         />
         <Route
-          path="/laudos/:nLab/editar"
+          path="/laudos/:id/editar"
           element={
             <AppShell>
               <Suspense fallback={<Spinner />}>

--- a/labas-web/src/components/layout/AppSidebar.tsx
+++ b/labas-web/src/components/layout/AppSidebar.tsx
@@ -12,6 +12,7 @@ import DashboardIcon from "@mui/icons-material/Dashboard";
 import ScienceIcon from "@mui/icons-material/Science";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 import PeopleIcon from "@mui/icons-material/People";
+import BiotechIcon from "@mui/icons-material/Biotech";
 import { NavLink } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
 
@@ -27,6 +28,7 @@ const navComum = [
 
 /** Itens de navegação exclusivos de staff */
 const navStaff = [
+  { label: "Amostras", icon: <BiotechIcon />, to: "/entrada-lote" },
   { label: "Calibração", icon: <ScienceIcon />, to: "/calibracao" },
   { label: "Clientes", icon: <PeopleIcon />, to: "/clientes" },
 ];

--- a/labas-web/src/components/shared/DialogCorrecaoAnalise.tsx
+++ b/labas-web/src/components/shared/DialogCorrecaoAnalise.tsx
@@ -1,0 +1,355 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Grid,
+  Stack,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useCorrecaoAnalise } from "../../hooks/useCorrecaoAnalise";
+import type { LeituraDetalhe } from "../../types/analise";
+
+interface Props {
+  open: boolean;
+  laudoId: number;
+  analiseId: number;
+  onClose: () => void;
+}
+
+// ─── Aba 0: Correção de Bancada ───────────────────────────────────────────────
+
+interface TabBancadaProps {
+  leituras: LeituraDetalhe[];
+  salvando: boolean;
+  onCorrigir: (
+    leituraId: number,
+    leitura_bruta: number,
+    fator_diluicao: number | null,
+  ) => void;
+}
+
+function TabBancada({ leituras, salvando, onCorrigir }: TabBancadaProps) {
+  // Estado local: mapa de leituraId -> { leitura_bruta, fator_diluicao }
+  const [valores, setValores] = useState<
+    Record<number, { leitura_bruta: string; fator_diluicao: string }>
+  >(() =>
+    Object.fromEntries(
+      leituras.map((l) => [
+        l.id,
+        {
+          leitura_bruta: String(l.leitura_bruta),
+          fator_diluicao:
+            l.fator_diluicao != null ? String(l.fator_diluicao) : "",
+        },
+      ]),
+    ),
+  );
+
+  if (leituras.length === 0) {
+    return (
+      <Alert severity="info" sx={{ mt: 2 }}>
+        Nenhuma leitura de bancada registrada para esta amostra.
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack spacing={3} mt={2}>
+      <Alert severity="info">
+        Ao salvar uma leitura corrigida, o backend recalcula automaticamente os
+        índices <strong>SB, CTC, V% e m%</strong> via signal.
+      </Alert>
+
+      {leituras.map((l) => {
+        const v = valores[l.id] ?? {
+          leitura_bruta: String(l.leitura_bruta),
+          fator_diluicao: "",
+        };
+        const leituraNum = parseFloat(v.leitura_bruta);
+        const fatorNum =
+          v.fator_diluicao !== "" ? parseFloat(v.fator_diluicao) : null;
+        const invalido = isNaN(leituraNum);
+
+        return (
+          <Box key={l.id}>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              mb={1}
+            >
+              <Typography variant="subtitle2" fontWeight={700}>
+                {l.elemento_display}{" "}
+                <Typography
+                  component="span"
+                  variant="body2"
+                  color="text.secondary"
+                >
+                  ({l.equipamento})
+                </Typography>
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Resultado atual:{" "}
+                <strong>
+                  {l.resultado_calculado != null
+                    ? l.resultado_calculado.toFixed(3)
+                    : "—"}
+                </strong>
+              </Typography>
+            </Stack>
+
+            <Grid container spacing={1} alignItems="flex-end">
+              <Grid size={{ xs: 12, sm: 5 }}>
+                <TextField
+                  label="Leitura bruta corrigida *"
+                  size="small"
+                  fullWidth
+                  type="number"
+                  value={v.leitura_bruta}
+                  onChange={(e) =>
+                    setValores((prev) => ({
+                      ...prev,
+                      [l.id]: { ...prev[l.id], leitura_bruta: e.target.value },
+                    }))
+                  }
+                  error={invalido}
+                  helperText={invalido ? "Valor inválido" : undefined}
+                  inputProps={{ step: "any" }}
+                />
+              </Grid>
+
+              {/* Fator de diluição apenas para AA, FC, ES */}
+              {["AA", "FC", "ES"].includes(l.equipamento) && (
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <TextField
+                    label="Fator de diluição *"
+                    size="small"
+                    fullWidth
+                    type="number"
+                    value={v.fator_diluicao}
+                    onChange={(e) =>
+                      setValores((prev) => ({
+                        ...prev,
+                        [l.id]: {
+                          ...prev[l.id],
+                          fator_diluicao: e.target.value,
+                        },
+                      }))
+                    }
+                    inputProps={{ step: "any", min: 1 }}
+                  />
+                </Grid>
+              )}
+
+              <Grid size={{ xs: 12, sm: 3 }}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  fullWidth
+                  disabled={salvando || invalido}
+                  onClick={() => onCorrigir(l.id, leituraNum, fatorNum)}
+                >
+                  Salvar
+                </Button>
+              </Grid>
+            </Grid>
+            <Divider sx={{ mt: 2 }} />
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+}
+
+// ─── Aba 1: Granulometria ─────────────────────────────────────────────────────
+
+interface TabGranulometriaProps {
+  areia: number | null;
+  argila: number | null;
+  silte: number | null;
+  salvando: boolean;
+  onSalvar: (v: {
+    areia: number | null;
+    argila: number | null;
+    silte: number | null;
+  }) => void;
+}
+
+function TabGranulometria({
+  areia,
+  argila,
+  silte,
+  salvando,
+  onSalvar,
+}: TabGranulometriaProps) {
+  const [v, setV] = useState({
+    areia: areia != null ? String(areia) : "",
+    argila: argila != null ? String(argila) : "",
+    silte: silte != null ? String(silte) : "",
+  });
+
+  const toNum = (s: string) => (s === "" ? null : parseFloat(s));
+  const soma =
+    (toNum(v.areia) ?? 0) + (toNum(v.argila) ?? 0) + (toNum(v.silte) ?? 0);
+  const somaInvalida = soma > 100.01;
+
+  return (
+    <Stack spacing={2} mt={2}>
+      {somaInvalida && (
+        <Alert severity="warning">
+          Soma de areia + argila + silte não pode ultrapassar 100%. Atual:{" "}
+          <strong>{soma.toFixed(1)}%</strong>
+        </Alert>
+      )}
+
+      <Grid container spacing={2}>
+        {(
+          [
+            { key: "areia", label: "Areia (%)" },
+            { key: "argila", label: "Argila (%)" },
+            { key: "silte", label: "Silte (%)" },
+          ] as const
+        ).map(({ key, label }) => (
+          <Grid key={key} size={{ xs: 12, sm: 4 }}>
+            <TextField
+              label={label}
+              size="small"
+              fullWidth
+              type="number"
+              value={v[key]}
+              onChange={(e) =>
+                setV((prev) => ({ ...prev, [key]: e.target.value }))
+              }
+              inputProps={{ step: "any", min: 0, max: 100 }}
+            />
+          </Grid>
+        ))}
+      </Grid>
+
+      <Box>
+        <Button
+          variant="contained"
+          disabled={salvando || somaInvalida}
+          onClick={() =>
+            onSalvar({
+              areia: toNum(v.areia),
+              argila: toNum(v.argila),
+              silte: toNum(v.silte),
+            })
+          }
+        >
+          {salvando ? "Salvando..." : "Salvar Granulometria"}
+        </Button>
+      </Box>
+    </Stack>
+  );
+}
+
+// ─── Dialog principal ─────────────────────────────────────────────────────────
+
+export default function DialogCorrecaoAnalise({
+  open,
+  laudoId,
+  analiseId,
+  onClose,
+}: Props) {
+  const [aba, setAba] = useState(0);
+  const {
+    analise,
+    leituras,
+    loading,
+    salvando,
+    corrigirLeitura,
+    salvarGranulometria,
+  } = useCorrecaoAnalise(
+    open ? laudoId : undefined,
+    open ? analiseId : undefined,
+  );
+
+  const handleCorrigir = async (
+    leituraId: number,
+    leitura_bruta: number,
+    fator_diluicao: number | null,
+  ) => {
+    await corrigirLeitura(leituraId, {
+      leitura_bruta,
+      ...(fator_diluicao != null ? { fator_diluicao } : {}),
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      scroll="paper"
+    >
+      <DialogTitle>
+        <Typography variant="h6" component="span">
+          Correção da Amostra
+        </Typography>
+        {analise && (
+          <Typography
+            variant="h5"
+            component="div"
+            fontWeight={800}
+            color="primary"
+          >
+            {analise.n_lab}
+          </Typography>
+        )}
+      </DialogTitle>
+
+      <Tabs
+        value={aba}
+        onChange={(_, v: number) => setAba(v)}
+        sx={{ px: 3, borderBottom: 1, borderColor: "divider" }}
+      >
+        <Tab label="Correção de Bancada" />
+        <Tab label="Granulometria" />
+      </Tabs>
+
+      <DialogContent>
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={4}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <>
+            {aba === 0 && (
+              <TabBancada
+                leituras={leituras}
+                salvando={salvando}
+                onCorrigir={handleCorrigir}
+              />
+            )}
+            {aba === 1 && analise && (
+              <TabGranulometria
+                areia={analise.areia}
+                argila={analise.argila}
+                silte={analise.silte}
+                salvando={salvando}
+                onSalvar={salvarGranulometria}
+              />
+            )}
+          </>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Fechar</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/labas-web/src/hooks/useAnalises.ts
+++ b/labas-web/src/hooks/useAnalises.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from "react";
+import { analiseService } from "../services/analiseService";
+import { useSnackbar } from "./useSnackbar";
+import type { AnaliseSolo, AnaliseSoloPayload } from "../types/analise";
+
+export interface UseAnalisesResult {
+  analises: AnaliseSolo[];
+  loading: boolean;
+  salvando: boolean;
+  editando: number | null;
+  removendo: number | null;
+  criar: (payload: Omit<AnaliseSoloPayload, "laudo_id">) => Promise<void>;
+  editar: (
+    analiseId: number,
+    payload: Partial<Omit<AnaliseSoloPayload, "laudo_id">>,
+  ) => Promise<void>;
+  toggleAtivo: (analiseId: number, ativo: boolean) => Promise<void>;
+  remover: (analiseId: number) => Promise<void>;
+  recarregar: () => void;
+}
+
+export function useAnalises(laudoId: number | undefined): UseAnalisesResult {
+  const { showSuccess, showApiError } = useSnackbar();
+  const [analises, setAnalises] = useState<AnaliseSolo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [salvando, setSalvando] = useState(false);
+  const [editando, setEditando] = useState<number | null>(null);
+  const [removendo, setRemovendo] = useState<number | null>(null);
+
+  const carregar = useCallback(async () => {
+    if (!laudoId) return;
+    setLoading(true);
+    try {
+      const data = await analiseService.listar(laudoId);
+      setAnalises(data);
+    } catch (err) {
+      showApiError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [laudoId, showApiError]);
+
+  useEffect(() => {
+    void carregar();
+  }, [carregar]);
+
+  const criar = useCallback(
+    async (payload: Omit<AnaliseSoloPayload, "laudo_id">) => {
+      if (!laudoId) return;
+      setSalvando(true);
+      try {
+        const novaAnalise = await analiseService.criar(laudoId, payload);
+        setAnalises((prev) => [...prev, novaAnalise]);
+        showSuccess("Análise adicionada com sucesso.");
+      } catch (err) {
+        showApiError(err);
+      } finally {
+        setSalvando(false);
+      }
+    },
+    [laudoId, showSuccess, showApiError],
+  );
+
+  const editar = useCallback(
+    async (
+      analiseId: number,
+      payload: Partial<Omit<AnaliseSoloPayload, "laudo_id">>,
+    ) => {
+      if (!laudoId) return;
+      setEditando(analiseId);
+      try {
+        const atualizada = await analiseService.atualizar(
+          laudoId,
+          analiseId,
+          payload,
+        );
+        setAnalises((prev) =>
+          prev.map((a) => (a.id === analiseId ? atualizada : a)),
+        );
+        showSuccess("Análise atualizada com sucesso.");
+      } catch (err) {
+        showApiError(err);
+      } finally {
+        setEditando(null);
+      }
+    },
+    [laudoId, showSuccess, showApiError],
+  );
+
+  const toggleAtivo = useCallback(
+    async (analiseId: number, ativo: boolean) => {
+      if (!laudoId) return;
+      try {
+        const atualizada = await analiseService.toggleAtivo(
+          laudoId,
+          analiseId,
+          ativo,
+        );
+        setAnalises((prev) =>
+          prev.map((a) => (a.id === analiseId ? atualizada : a)),
+        );
+      } catch (err) {
+        showApiError(err);
+      }
+    },
+    [laudoId, showApiError],
+  );
+
+  const remover = useCallback(
+    async (analiseId: number) => {
+      if (!laudoId) return;
+      setRemovendo(analiseId);
+      try {
+        await analiseService.remover(laudoId, analiseId);
+        setAnalises((prev) => prev.filter((a) => a.id !== analiseId));
+        showSuccess("Análise removida.");
+      } catch (err) {
+        showApiError(err);
+      } finally {
+        setRemovendo(null);
+      }
+    },
+    [laudoId, showSuccess, showApiError],
+  );
+
+  return {
+    analises,
+    loading,
+    salvando,
+    editando,
+    removendo,
+    criar,
+    editar,
+    toggleAtivo,
+    remover,
+    recarregar: carregar,
+  };
+}

--- a/labas-web/src/hooks/useCorrecaoAnalise.ts
+++ b/labas-web/src/hooks/useCorrecaoAnalise.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useState } from "react";
+import { correcaoService } from "../services/correcaoService";
+import { analiseService } from "../services/analiseService";
+import { useSnackbar } from "./useSnackbar";
+import type {
+  AnaliseSolo,
+  LeituraDetalhe,
+  LeituraCorrecaoPayload,
+} from "../types/analise";
+
+export interface UseCorrecaoAnaliseResult {
+  analise: AnaliseSolo | null;
+  leituras: LeituraDetalhe[];
+  loading: boolean;
+  salvando: boolean;
+  corrigirLeitura: (
+    leituraId: number,
+    payload: LeituraCorrecaoPayload,
+  ) => Promise<void>;
+  salvarGranulometria: (payload: {
+    areia?: number | null;
+    argila?: number | null;
+    silte?: number | null;
+  }) => Promise<void>;
+}
+
+export function useCorrecaoAnalise(
+  laudoId: number | undefined,
+  analiseId: number | undefined,
+): UseCorrecaoAnaliseResult {
+  const { showSuccess, showApiError } = useSnackbar();
+  const [analise, setAnalise] = useState<AnaliseSolo | null>(null);
+  const [leituras, setLeituras] = useState<LeituraDetalhe[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [salvando, setSalvando] = useState(false);
+
+  const carregar = useCallback(async () => {
+    if (!laudoId || !analiseId) return;
+    setLoading(true);
+    try {
+      const [dadosAnalise, dadosLeituras] = await Promise.all([
+        analiseService.buscar(laudoId, analiseId),
+        correcaoService.listarLeituras(analiseId),
+      ]);
+      setAnalise(dadosAnalise);
+      setLeituras(dadosLeituras);
+    } catch (err) {
+      showApiError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [laudoId, analiseId, showApiError]);
+
+  useEffect(() => {
+    void carregar();
+  }, [carregar]);
+
+  const corrigirLeitura = useCallback(
+    async (leituraId: number, payload: LeituraCorrecaoPayload) => {
+      setSalvando(true);
+      try {
+        const atualizada = await correcaoService.corrigirLeitura(
+          leituraId,
+          payload,
+        );
+        setLeituras((prev) =>
+          prev.map((l) => (l.id === leituraId ? atualizada : l)),
+        );
+        // Re-carrega a analise para refletir os índices recalculados (SB, CTC, V%...)
+        if (laudoId && analiseId) {
+          const analiseAtualizada = await analiseService.buscar(
+            laudoId,
+            analiseId,
+          );
+          setAnalise(analiseAtualizada);
+        }
+        showSuccess("Leitura corrigida. Índices recalculados.");
+      } catch (err) {
+        showApiError(err);
+      } finally {
+        setSalvando(false);
+      }
+    },
+    [laudoId, analiseId, showSuccess, showApiError],
+  );
+
+  const salvarGranulometria = useCallback(
+    async (payload: {
+      areia?: number | null;
+      argila?: number | null;
+      silte?: number | null;
+    }) => {
+      if (!laudoId || !analiseId) return;
+      setSalvando(true);
+      try {
+        const atualizada = await analiseService.atualizar(
+          laudoId,
+          analiseId,
+          payload,
+        );
+        setAnalise(atualizada);
+        showSuccess("Granulometria salva.");
+      } catch (err) {
+        showApiError(err);
+      } finally {
+        setSalvando(false);
+      }
+    },
+    [laudoId, analiseId, showSuccess, showApiError],
+  );
+
+  return {
+    analise,
+    leituras,
+    loading,
+    salvando,
+    corrigirLeitura,
+    salvarGranulometria,
+  };
+}

--- a/labas-web/src/hooks/useLaudoEditForm.ts
+++ b/labas-web/src/hooks/useLaudoEditForm.ts
@@ -10,49 +10,16 @@ import {
 } from "../schemas/laudoSchemas";
 import { laudoService } from "../services/laudoService";
 import { useSnackbar } from "./useSnackbar";
-import type { AnaliseSolo, AnaliseSoloPayload } from "../types/analise";
+import type { Laudo, LaudoPayload } from "../types/analise";
 
-const numericField = (value: number | null): number | "" =>
-  value === null ? "" : value;
-
-const buildDefaultValues = (laudo: AnaliseSolo): LaudoFormInput => ({
-  n_lab: laudo.n_lab,
+const buildDefaultValues = (laudo: Laudo): LaudoFormInput => ({
   cliente_codigo: laudo.cliente.codigo,
-  data_entrada: laudo.data_entrada,
+  data_emissao: laudo.data_emissao,
   data_saida: laudo.data_saida ?? "",
-  ph_agua: numericField(laudo.ph_agua),
-  ph_cacl2: numericField(laudo.ph_cacl2),
-  ph_kcl: numericField(laudo.ph_kcl),
-  p_m: numericField(laudo.p_m),
-  p_r: numericField(laudo.p_r),
-  p_rem: numericField(laudo.p_rem),
-  mo: numericField(laudo.mo),
-  s: numericField(laudo.s),
-  b: numericField(laudo.b),
-  k: numericField(laudo.k),
-  na: numericField(laudo.na),
-  ca: numericField(laudo.ca),
-  mg: numericField(laudo.mg),
-  cu: numericField(laudo.cu),
-  fe: numericField(laudo.fe),
-  mn: numericField(laudo.mn),
-  zn: numericField(laudo.zn),
-  al: numericField(laudo.al),
-  h_al: numericField(laudo.h_al),
-  areia: numericField(laudo.areia),
-  argila: numericField(laudo.argila),
-  silte: numericField(laudo.silte),
+  observacoes: laudo.observacoes ?? "",
 });
 
-const normalizePayload = (data: LaudoForm): Partial<AnaliseSoloPayload> => {
-  const entries = Object.entries(data).map(([key, value]) => [
-    key,
-    value === undefined || value === "" ? null : value,
-  ]);
-  return Object.fromEntries(entries) as Partial<AnaliseSoloPayload>;
-};
-
-export function useLaudoEditForm(laudo?: AnaliseSolo) {
+export function useLaudoEditForm(laudo?: Laudo) {
   const navigate = useNavigate();
   const { showSuccess, showApiError } = useSnackbar();
   const [submitting, setSubmitting] = useState(false);
@@ -60,14 +27,13 @@ export function useLaudoEditForm(laudo?: AnaliseSolo) {
   const form = useForm<LaudoFormInput, unknown, LaudoForm>({
     resolver: zodResolver(laudoSchema),
     defaultValues: {
-      n_lab: "",
       cliente_codigo: "",
-      data_entrada: "",
+      data_emissao: "",
       data_saida: "",
+      observacoes: "",
     },
   });
 
-  // Popula o formulário quando o laudo for carregado assincronamente
   useEffect(() => {
     if (!laudo) return;
     form.reset(buildDefaultValues(laudo));
@@ -77,7 +43,13 @@ export function useLaudoEditForm(laudo?: AnaliseSolo) {
     if (!laudo) return;
     setSubmitting(true);
     try {
-      await laudoService.atualizar(laudo.n_lab, normalizePayload(data));
+      const payload: Partial<LaudoPayload> = {
+        cliente_codigo: data.cliente_codigo,
+        data_emissao: data.data_emissao,
+        data_saida: data.data_saida || null,
+        observacoes: data.observacoes || undefined,
+      };
+      await laudoService.atualizar(laudo.id, payload);
       showSuccess("Laudo atualizado com sucesso.");
       navigate("/laudos");
     } catch (err) {
@@ -97,9 +69,7 @@ export function useLaudoEditForm(laudo?: AnaliseSolo) {
             hasFieldError = true;
           }
         });
-        if (!hasFieldError) {
-          showApiError(err);
-        }
+        if (!hasFieldError) showApiError(err);
         return;
       }
       showApiError(err);

--- a/labas-web/src/hooks/useLaudoForm.ts
+++ b/labas-web/src/hooks/useLaudoForm.ts
@@ -10,18 +10,9 @@ import {
 } from "../schemas/laudoSchemas";
 import { laudoService } from "../services/laudoService";
 import { useSnackbar } from "./useSnackbar";
-import type { AnaliseSoloPayload } from "../types/analise";
+import type { LaudoPayload } from "../types/analise";
 
 const getTodayISO = () => new Date().toISOString().slice(0, 10);
-
-const normalizePayload = (data: LaudoForm): AnaliseSoloPayload => {
-  const entries = Object.entries(data).map(([key, value]) => [
-    key,
-    value === undefined || value === "" ? null : value,
-  ]);
-
-  return Object.fromEntries(entries) as AnaliseSoloPayload;
-};
 
 export function useLaudoForm() {
   const navigate = useNavigate();
@@ -31,21 +22,24 @@ export function useLaudoForm() {
   const form = useForm<LaudoFormInput, unknown, LaudoForm>({
     resolver: zodResolver(laudoSchema),
     defaultValues: {
-      n_lab: "",
       cliente_codigo: "",
-      data_entrada: getTodayISO(),
-      data_saida: "",
+      data_emissao: getTodayISO(),
+      observacoes: "",
     },
   });
 
   const onSubmit = form.handleSubmit(async (data) => {
     setSubmitting(true);
     try {
-      await laudoService.criar(normalizePayload(data));
+      const payload: LaudoPayload = {
+        cliente_codigo: data.cliente_codigo,
+        data_emissao: data.data_emissao,
+        observacoes: data.observacoes || undefined,
+      };
+      const laudo = await laudoService.criar(payload);
       showSuccess("Laudo criado com sucesso.");
-      navigate("/laudos");
+      navigate(`/laudos/${laudo.id}/editar`);
     } catch (err) {
-      // Mapeia erros de campo (400) de volta para os inputs do formulário
       const responseData = (err as { response?: { data?: unknown } })?.response
         ?.data;
       if (responseData && typeof responseData === "object") {
@@ -62,10 +56,7 @@ export function useLaudoForm() {
             hasFieldError = true;
           }
         });
-        // Exibe no Snackbar apenas o que não mapeou para um campo do form
-        if (!hasFieldError) {
-          showApiError(err);
-        }
+        if (!hasFieldError) showApiError(err);
         return;
       }
       showApiError(err);
@@ -74,9 +65,5 @@ export function useLaudoForm() {
     }
   });
 
-  return {
-    form,
-    submitting,
-    onSubmit,
-  };
+  return { form, submitting, onSubmit };
 }

--- a/labas-web/src/hooks/useLaudos.ts
+++ b/labas-web/src/hooks/useLaudos.ts
@@ -1,25 +1,25 @@
 import { useCallback, useEffect, useState } from "react";
 import { laudoService } from "../services/laudoService";
 import { useSnackbar } from "./useSnackbar";
-import type { AnaliseSolo } from "../types/analise";
+import type { Laudo } from "../types/analise";
 
 export interface UseLaudosResult {
-  laudos: AnaliseSolo[];
+  laudos: Laudo[];
   loading: boolean;
-  deletando: string | null; // n_lab sendo deletado (para loading por linha)
-  baixarPdf: (nLab: string) => Promise<void>;
-  excluir: (nLab: string) => Promise<void>;
+  deletando: number | null;
+  baixarPdf: (id: number, codigoLaudo: string) => Promise<void>;
+  excluir: (id: number) => Promise<void>;
   recarregar: () => void;
 }
 
-const criarNomeArquivo = (nLab: string) =>
-  `laudo_${nLab.replace("/", "-")}.pdf`;
+const criarNomeArquivo = (codigoLaudo: string) =>
+  `laudo_${codigoLaudo.replace("/", "-")}.pdf`;
 
 export function useLaudos(): UseLaudosResult {
   const { showSuccess, showApiError } = useSnackbar();
-  const [laudos, setLaudos] = useState<AnaliseSolo[]>([]);
+  const [laudos, setLaudos] = useState<Laudo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [deletando, setDeletando] = useState<string | null>(null);
+  const [deletando, setDeletando] = useState<number | null>(null);
 
   const carregar = useCallback(async () => {
     setLoading(true);
@@ -38,13 +38,13 @@ export function useLaudos(): UseLaudosResult {
   }, [carregar]);
 
   const baixarPdf = useCallback(
-    async (nLab: string) => {
+    async (id: number, codigoLaudo: string) => {
       try {
-        const blob = await laudoService.baixarPdf(nLab);
+        const blob = await laudoService.baixarPdf(id);
         const url = window.URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = url;
-        link.download = criarNomeArquivo(nLab);
+        link.download = criarNomeArquivo(codigoLaudo);
         link.style.display = "none";
         document.body.appendChild(link);
         link.click();
@@ -58,12 +58,12 @@ export function useLaudos(): UseLaudosResult {
   );
 
   const excluir = useCallback(
-    async (nLab: string) => {
-      setDeletando(nLab);
+    async (id: number) => {
+      setDeletando(id);
       try {
-        await laudoService.remover(nLab);
-        showSuccess(`Laudo ${nLab} excluído com sucesso.`);
-        setLaudos((prev) => prev.filter((l) => l.n_lab !== nLab));
+        await laudoService.remover(id);
+        showSuccess("Laudo excluído com sucesso.");
+        setLaudos((prev) => prev.filter((l) => l.id !== id));
       } catch (err) {
         showApiError(err);
       } finally {

--- a/labas-web/src/pages/laudos/LaudoDetalhePage.tsx
+++ b/labas-web/src/pages/laudos/LaudoDetalhePage.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  Grid,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import DownloadIcon from "@mui/icons-material/Download";
+import EditIcon from "@mui/icons-material/Edit";
+import { Link as RouterLink, useParams } from "react-router-dom";
+import { DataGrid, type GridColDef } from "@mui/x-data-grid";
+import PageHeader from "../../components/shared/PageHeader";
+import LoadingOverlay from "../../components/shared/LoadingOverlay";
+import { laudoService } from "../../services/laudoService";
+import { useAnalises } from "../../hooks/useAnalises";
+import { useSnackbar } from "../../hooks/useSnackbar";
+import { useAuth } from "../../hooks/useAuth";
+import type { Laudo, AnaliseSolo } from "../../types/analise";
+
+// ─── Colunas do DataGrid (somente leitura) ───────────────────────────────────
+
+const colunas: GridColDef<AnaliseSolo>[] = [
+  { field: "n_lab", headerName: "N° Lab", width: 110 },
+  {
+    field: "referencia",
+    headerName: "Referência",
+    width: 150,
+    valueGetter: (_val, row) => row.referencia ?? "—",
+  },
+  { field: "data_entrada", headerName: "Data Entrada", width: 120 },
+  {
+    field: "ativo",
+    headerName: "Status",
+    width: 100,
+    renderCell: ({ value }) =>
+      value ? (
+        <Chip label="Ativa" color="success" size="small" />
+      ) : (
+        <Chip label="Inativa" size="small" />
+      ),
+  },
+  {
+    field: "sb",
+    headerName: "SB",
+    width: 90,
+    type: "number",
+    valueGetter: (_val, row) => row.sb ?? "—",
+  },
+  {
+    field: "T_maiusculo",
+    headerName: "CTC",
+    width: 90,
+    type: "number",
+    valueGetter: (_val, row) => row.T_maiusculo ?? "—",
+  },
+  {
+    field: "V",
+    headerName: "V%",
+    width: 80,
+    type: "number",
+    valueGetter: (_val, row) => row.V ?? "—",
+  },
+  {
+    field: "m",
+    headerName: "m%",
+    width: 80,
+    type: "number",
+    valueGetter: (_val, row) => row.m ?? "—",
+  },
+  {
+    field: "ph_agua",
+    headerName: "pH (água)",
+    width: 100,
+    type: "number",
+    valueGetter: (_val, row) => row.ph_agua ?? "—",
+  },
+];
+
+// ─── Componente ──────────────────────────────────────────────────────────────
+
+export default function LaudoDetalhePage() {
+  const { id: idParam } = useParams<{ id: string }>();
+  const laudoId = idParam ? parseInt(idParam, 10) : undefined;
+
+  const { isStaff } = useAuth();
+  const { showApiError } = useSnackbar();
+
+  const [laudo, setLaudo] = useState<Laudo | null>(null);
+  const [buscando, setBuscando] = useState(true);
+  const [erroFetch, setErroFetch] = useState(false);
+  const [baixando, setBaixando] = useState(false);
+
+  const { analises, loading: analisesLoading } = useAnalises(laudoId);
+
+  useEffect(() => {
+    if (!laudoId || isNaN(laudoId)) {
+      setErroFetch(true);
+      setBuscando(false);
+      return;
+    }
+    laudoService
+      .buscar(laudoId)
+      .then(setLaudo)
+      .catch((err) => {
+        showApiError(err);
+        setErroFetch(true);
+      })
+      .finally(() => setBuscando(false));
+  }, [laudoId, showApiError]);
+
+  const handleBaixarPdf = async () => {
+    if (!laudo) return;
+    setBaixando(true);
+    try {
+      const blob = await laudoService.baixarPdf(laudo.id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `laudo-${laudo.codigo_laudo}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      showApiError(err);
+    } finally {
+      setBaixando(false);
+    }
+  };
+
+  if (buscando) {
+    return (
+      <Box display="flex" justifyContent="center" py={8}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (erroFetch || !laudo) {
+    return (
+      <Box>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Não foi possível carregar o laudo. Verifique o identificador e tente
+          novamente.
+        </Alert>
+        <Button variant="outlined" component={RouterLink} to="/laudos">
+          Voltar para laudos
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <LoadingOverlay open={baixando} message="Gerando PDF..." />
+
+      <PageHeader
+        title={`Laudo ${laudo.codigo_laudo}`}
+        subtitle={`${laudo.cliente.nome} (${laudo.cliente.codigo})`}
+      />
+
+      {/* ── Cabeçalho ──────────────────────────────────────────────────────── */}
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Dados do laudo
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <Typography variant="caption" color="text.secondary">
+              Código
+            </Typography>
+            <Typography variant="body1" fontWeight={600}>
+              {laudo.codigo_laudo}
+            </Typography>
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <Typography variant="caption" color="text.secondary">
+              Data de Emissão
+            </Typography>
+            <Typography variant="body1">{laudo.data_emissao}</Typography>
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <Typography variant="caption" color="text.secondary">
+              Cliente
+            </Typography>
+            <Typography variant="body1">{laudo.cliente.nome}</Typography>
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <Typography variant="caption" color="text.secondary">
+              Município
+            </Typography>
+            <Typography variant="body1">
+              {laudo.cliente.municipio ?? "—"}
+            </Typography>
+          </Grid>
+
+          {laudo.observacoes && (
+            <Grid size={12}>
+              <Divider sx={{ my: 1 }} />
+              <Typography variant="caption" color="text.secondary">
+                Observações
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: "pre-line" }}>
+                {laudo.observacoes}
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+      </Paper>
+
+      {/* ── Análises ───────────────────────────────────────────────────────── */}
+      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+        <Typography variant="subtitle1" fontWeight={700} mb={2}>
+          Análises ({analises.filter((a) => a.ativo).length} ativas)
+        </Typography>
+        <Box sx={{ height: 400 }}>
+          <DataGrid
+            rows={analises}
+            columns={colunas}
+            loading={analisesLoading}
+            density="compact"
+            disableRowSelectionOnClick
+            pageSizeOptions={[10, 25, 50]}
+            initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+          />
+        </Box>
+      </Paper>
+
+      {/* ── Ações ──────────────────────────────────────────────────────────── */}
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+        <Button variant="outlined" component={RouterLink} to="/laudos">
+          Voltar
+        </Button>
+
+        <Tooltip title="Baixar PDF com todas as análises ativas">
+          <span>
+            <Button
+              variant="contained"
+              startIcon={<DownloadIcon />}
+              onClick={() => void handleBaixarPdf()}
+              disabled={baixando}
+            >
+              {baixando ? "Gerando..." : "Gerar PDF"}
+            </Button>
+          </span>
+        </Tooltip>
+
+        {isStaff && (
+          <Button
+            variant="outlined"
+            startIcon={<EditIcon />}
+            component={RouterLink}
+            to={`/laudos/${laudo.id}/editar`}
+          >
+            Editar
+          </Button>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/labas-web/src/pages/laudos/LaudoEditPage.tsx
+++ b/labas-web/src/pages/laudos/LaudoEditPage.tsx
@@ -1,111 +1,61 @@
 import { useEffect, useMemo, useState } from "react";
 import { Controller } from "react-hook-form";
-import type { InputHTMLAttributes } from "react";
 import {
   Alert,
   Autocomplete,
   Box,
   Button,
+  Chip,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Grid,
+  IconButton,
   Paper,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
+import { DataGrid } from "@mui/x-data-grid";
+import type { GridColDef } from "@mui/x-data-grid";
+import AddIcon from "@mui/icons-material/Add";
+import BiotechIcon from "@mui/icons-material/Biotech";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import ScienceIcon from "@mui/icons-material/Science";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
 import PageHeader from "../../components/shared/PageHeader";
 import LoadingOverlay from "../../components/shared/LoadingOverlay";
+import ConfirmDialog from "../../components/shared/ConfirmDialog";
+import DialogCorrecaoAnalise from "../../components/shared/DialogCorrecaoAnalise";
 import { useLaudoEditForm } from "../../hooks/useLaudoEditForm";
+import { useAnalises } from "../../hooks/useAnalises";
 import { useClientes } from "../../hooks/useClientes";
 import { laudoService } from "../../services/laudoService";
 import { useSnackbar } from "../../hooks/useSnackbar";
 import type { Cliente } from "../../types/cliente";
-import type { AnaliseSolo } from "../../types/analise";
-import type { LaudoForm } from "../../schemas/laudoSchemas";
-
-const decimalInputProps = {
-  inputMode: "decimal" as const,
-  pattern: "[0-9]*[.,]?[0-9]*",
-};
-
-type FieldName = keyof LaudoForm;
-
-type FieldConfig = {
-  name: FieldName;
-  label: string;
-  inputProps?: InputHTMLAttributes<HTMLInputElement>;
-};
-
-const PH_FIELDS: FieldConfig[] = [
-  { name: "ph_agua", label: "pH água" },
-  { name: "ph_cacl2", label: "pH CaCl₂" },
-  { name: "ph_kcl", label: "pH KCl" },
-];
-
-const ESPECTRO_FIELDS: FieldConfig[] = [
-  { name: "p_m", label: "P Mehlich (mg/dm³)" },
-  { name: "p_r", label: "P Resina (mg/dm³)" },
-  { name: "p_rem", label: "P Rem (mg/L)" },
-  { name: "mo", label: "Matéria Orgânica (dag/kg)" },
-  { name: "s", label: "Enxofre (mg/dm³)" },
-  { name: "b", label: "Boro (mg/dm³)" },
-];
-
-const FOTOMETRO_FIELDS: FieldConfig[] = [
-  { name: "k", label: "Potássio (mg/dm³)" },
-  { name: "na", label: "Sódio (mg/dm³)" },
-];
-
-const ABSORCAO_FIELDS: FieldConfig[] = [
-  { name: "ca", label: "Cálcio (cmolc/dm³)" },
-  { name: "mg", label: "Magnésio (cmolc/dm³)" },
-  { name: "cu", label: "Cobre (mg/dm³)" },
-  { name: "fe", label: "Ferro (mg/dm³)" },
-  { name: "mn", label: "Manganês (mg/dm³)" },
-  { name: "zn", label: "Zinco (mg/dm³)" },
-];
-
-const TITULACAO_FIELDS: FieldConfig[] = [
-  { name: "al", label: "Alumínio (cmolc/dm³)" },
-  { name: "h_al", label: "Acidez Potencial (cmolc/dm³)" },
-];
-
-const GRANULOMETRIA_FIELDS: FieldConfig[] = [
-  { name: "areia", label: "Areia (%)" },
-  { name: "argila", label: "Argila (%)" },
-  { name: "silte", label: "Silte (%)" },
-];
-
-const renderNumberField = (
-  field: FieldConfig,
-  getErrorMessage: (name: FieldName) => string | undefined,
-  register: ReturnType<typeof useLaudoEditForm>["form"]["register"],
-  disabled: boolean,
-) => (
-  <Grid size={{ xs: 12, sm: 6, md: 4 }} key={field.name}>
-    <TextField
-      fullWidth
-      size="small"
-      label={field.label}
-      type="text"
-      inputProps={field.inputProps ?? decimalInputProps}
-      error={!!getErrorMessage(field.name)}
-      helperText={getErrorMessage(field.name)}
-      disabled={disabled}
-      {...register(field.name)}
-    />
-  </Grid>
-);
+import type { Laudo, AnaliseSolo } from "../../types/analise";
 
 export default function LaudoEditPage() {
-  const { nLab: nLabParam } = useParams<{ nLab: string }>();
+  const { id: idParam } = useParams<{ id: string }>();
+  const laudoId = idParam ? parseInt(idParam, 10) : undefined;
   const navigate = useNavigate();
   const { showApiError } = useSnackbar();
 
-  const [laudo, setLaudo] = useState<AnaliseSolo | undefined>();
+  const [laudo, setLaudo] = useState<Laudo | undefined>();
   const [buscando, setBuscando] = useState(true);
   const [erroFetch, setErroFetch] = useState(false);
+  const [confirmarRemocao, setConfirmarRemocao] = useState<AnaliseSolo | null>(
+    null,
+  );
+  const [analiseCorrecao, setAnaliseCorrecao] = useState<AnaliseSolo | null>(
+    null,
+  );
 
   const [clienteSelecionado, setClienteSelecionado] = useState<Cliente | null>(
     null,
@@ -114,14 +64,93 @@ export default function LaudoEditPage() {
 
   const { clientes, loading: clientesLoading, buscar, limpar } = useClientes();
   const { form, submitting, onSubmit } = useLaudoEditForm(laudo);
+  const {
+    analises,
+    loading: analisesLoading,
+    salvando,
+    editando,
+    removendo,
+    remover,
+    toggleAtivo,
+    criar,
+    editar,
+  } = useAnalises(laudoId);
+
+  // ── Dialog "Nova Amostra" ─────────────────────────────────────────────────
+  const [dialogAberto, setDialogAberto] = useState(false);
+  const [nLabNovo, setNLabNovo] = useState("");
+  const [referenciaNova, setReferenciaNova] = useState("");
+  const [dataEntradaNova, setDataEntradaNova] = useState("");
+  const [erroNLab, setErroNLab] = useState("");
+
+  // ── Dialog "Editar Amostra" ───────────────────────────────────────────────
+  const [editandoAmostra, setEditandoAmostra] = useState<AnaliseSolo | null>(
+    null,
+  );
+  const [nLabEdit, setNLabEdit] = useState("");
+  const [referenciaEdit, setReferenciaEdit] = useState("");
+  const [dataEntradaEdit, setDataEntradaEdit] = useState("");
+  const [erroEdit, setErroEdit] = useState("");
+
+  const abrirDialogEdicao = (analise: AnaliseSolo) => {
+    setNLabEdit(analise.n_lab);
+    setReferenciaEdit(analise.referencia ?? "");
+    setDataEntradaEdit(analise.data_entrada);
+    setErroEdit("");
+    setEditandoAmostra(analise);
+  };
+
+  const handleEditarAmostra = async () => {
+    if (!/^\d{4}\/\d{3}$/.test(nLabEdit.trim())) {
+      setErroEdit("Formato inválido. Use AAAA/NNN (ex: 2026/001)");
+      return;
+    }
+    if (!dataEntradaEdit) {
+      setErroEdit("Data de entrada obrigatória");
+      return;
+    }
+    if (!editandoAmostra) return;
+    await editar(editandoAmostra.id, {
+      n_lab: nLabEdit.trim(),
+      referencia: referenciaEdit || null,
+      data_entrada: dataEntradaEdit,
+    });
+    setEditandoAmostra(null);
+  };
+
+  const abrirDialog = () => {
+    setNLabNovo("");
+    setReferenciaNova("");
+    setDataEntradaNova("");
+    setErroNLab("");
+    setDialogAberto(true);
+  };
+
+  const handleCriarAmostra = async () => {
+    if (!/^\d{4}\/\d{3}$/.test(nLabNovo.trim())) {
+      setErroNLab("Formato inválido. Use AAAA/NNN (ex: 2026/001)");
+      return;
+    }
+    if (!dataEntradaNova) {
+      setErroNLab("Data de entrada obrigatória");
+      return;
+    }
+    await criar({
+      n_lab: nLabNovo.trim(),
+      referencia: referenciaNova || null,
+      data_entrada: dataEntradaNova,
+      ativo: true,
+    });
+    setDialogAberto(false);
+  };
 
   useEffect(() => {
-    if (!nLabParam) {
+    if (!laudoId) {
       navigate("/laudos");
       return;
     }
     laudoService
-      .buscar(decodeURIComponent(nLabParam))
+      .buscar(laudoId)
       .then((data) => {
         setLaudo(data);
         setClienteSelecionado(data.cliente);
@@ -132,18 +161,14 @@ export default function LaudoEditPage() {
         setErroFetch(true);
       })
       .finally(() => setBuscando(false));
-  }, [nLabParam, navigate, showApiError]);
+  }, [laudoId, navigate, showApiError]);
 
-  // Garante que o cliente atual sempre aparece na lista de opções do Autocomplete
   const clientesOpcoes = useMemo(() => {
     if (!clienteSelecionado) return clientes;
     if (clientes.some((c) => c.codigo === clienteSelecionado.codigo))
       return clientes;
     return [clienteSelecionado, ...clientes];
   }, [clientes, clienteSelecionado]);
-
-  const getErrorMessage = (name: FieldName) =>
-    form.formState.errors[name]?.message as string | undefined;
 
   const handleClienteInput = (_: React.SyntheticEvent, value: string) => {
     setClienteInput(value);
@@ -165,6 +190,93 @@ export default function LaudoEditPage() {
     buscar(value);
   };
 
+  const colunas: GridColDef<AnaliseSolo>[] = [
+    { field: "n_lab", headerName: "N° Lab", width: 110 },
+    { field: "referencia", headerName: "Referência", flex: 1 },
+    { field: "data_entrada", headerName: "Entrada", width: 110 },
+    {
+      field: "ativo",
+      headerName: "Ativo",
+      width: 90,
+      renderCell: ({ row }) => (
+        <Chip
+          size="small"
+          label={row.ativo ? "Sim" : "Não"}
+          color={row.ativo ? "success" : "default"}
+        />
+      ),
+    },
+    {
+      field: "sb",
+      headerName: "SB",
+      width: 80,
+      valueFormatter: (value: number | null) => value ?? "—",
+    },
+    {
+      field: "ctc",
+      headerName: "CTC",
+      width: 80,
+      valueFormatter: (value: number | null) => value ?? "—",
+    },
+    {
+      field: "v",
+      headerName: "V%",
+      width: 80,
+      valueFormatter: (value: number | null) =>
+        value != null ? `${value}%` : "—",
+    },
+    {
+      field: "acoes",
+      headerName: "Ações",
+      width: 100,
+      sortable: false,
+      renderCell: ({ row }) => (
+        <Stack direction="row" spacing={0.5}>
+          <Tooltip title="Editar ficha da amostra">
+            <IconButton
+              size="small"
+              disabled={editando === row.id}
+              onClick={() => abrirDialogEdicao(row)}
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Corrigir leituras / granulometria">
+            <IconButton
+              size="small"
+              color="secondary"
+              onClick={() => setAnaliseCorrecao(row)}
+            >
+              <ScienceIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={row.ativo ? "Desativar (oculta do PDF)" : "Ativar"}>
+            <IconButton
+              size="small"
+              onClick={() => void toggleAtivo(row.id, !row.ativo)}
+            >
+              {row.ativo ? (
+                <VisibilityOffIcon fontSize="small" />
+              ) : (
+                <VisibilityIcon fontSize="small" />
+              )}
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Remover análise">
+            <IconButton
+              size="small"
+              color="error"
+              disabled={removendo === row.id}
+              onClick={() => setConfirmarRemocao(row)}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      ),
+    },
+  ];
+
   if (buscando) {
     return (
       <Box display="flex" justifyContent="center" py={8}>
@@ -177,8 +289,7 @@ export default function LaudoEditPage() {
     return (
       <Box>
         <Alert severity="error" sx={{ mb: 2 }}>
-          Não foi possível carregar o laudo. Verifique o número e tente
-          novamente.
+          Não foi possível carregar o laudo.
         </Alert>
         <Button variant="outlined" component={RouterLink} to="/laudos">
           Voltar para laudos
@@ -192,50 +303,60 @@ export default function LaudoEditPage() {
       <LoadingOverlay open={submitting} message="Salvando alterações..." />
 
       <PageHeader
-        title={`Editar Laudo ${laudo.n_lab}`}
-        subtitle="Atualize os dados da análise de solo"
+        title={`Editar Laudo ${laudo.codigo_laudo}`}
+        subtitle="Atualize o cabeçalho e gerencie as análises vinculadas"
+        actions={
+          <Button
+            variant="contained"
+            startIcon={<BiotechIcon />}
+            component={RouterLink}
+            to="/entrada-lote"
+          >
+            Ir para Amostras
+          </Button>
+        }
       />
 
-      {/* ── Dados gerais ─────────────────────────────────────────────────── */}
+      {/* ── Cabeçalho ──────────────────────────────────────────────────── */}
       <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
         <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Dados gerais
+          Dados do laudo
         </Typography>
         <Grid container spacing={2}>
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+          <Grid size={{ xs: 12, sm: 4 }}>
             <TextField
               fullWidth
               size="small"
-              label="Nº do laudo"
-              value={laudo.n_lab}
+              label="Código"
+              value={laudo.codigo_laudo}
+              slotProps={{ input: { readOnly: true } }}
               disabled
-              InputProps={{ readOnly: true }}
             />
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+          <Grid size={{ xs: 12, sm: 4 }}>
             <TextField
               fullWidth
               size="small"
-              label="Data de entrada"
+              label="Data de Entrada *"
               type="date"
-              InputLabelProps={{ shrink: true }}
-              error={!!getErrorMessage("data_entrada")}
-              helperText={getErrorMessage("data_entrada")}
+              slotProps={{ inputLabel: { shrink: true } }}
+              error={!!form.formState.errors.data_emissao}
+              helperText={form.formState.errors.data_emissao?.message}
               disabled={submitting}
-              {...form.register("data_entrada")}
+              {...form.register("data_emissao")}
             />
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+          <Grid size={{ xs: 12, sm: 4 }}>
             <TextField
               fullWidth
               size="small"
-              label="Data de saída"
+              label="Data de Saída"
               type="date"
-              InputLabelProps={{ shrink: true }}
-              error={!!getErrorMessage("data_saida")}
-              helperText={getErrorMessage("data_saida")}
+              slotProps={{ inputLabel: { shrink: true } }}
+              error={!!form.formState.errors.data_saida}
+              helperText={form.formState.errors.data_saida?.message}
               disabled={submitting}
               {...form.register("data_saida")}
             />
@@ -271,7 +392,7 @@ export default function LaudoEditPage() {
                   renderInput={(params) => (
                     <TextField
                       {...params}
-                      label="Cliente"
+                      label="Cliente *"
                       size="small"
                       error={!!fieldState.error}
                       helperText={fieldState.error?.message}
@@ -282,127 +403,52 @@ export default function LaudoEditPage() {
             />
           </Grid>
 
-          <Grid size={{ xs: 12, md: 4 }}>
+          <Grid size={12}>
             <TextField
               fullWidth
               size="small"
-              label="Código do cliente"
-              value={clienteSelecionado?.codigo ?? ""}
-              InputProps={{ readOnly: true }}
-              placeholder="Selecione um cliente"
+              label="Observações"
+              multiline
+              rows={2}
+              disabled={submitting}
+              {...form.register("observacoes")}
             />
           </Grid>
-
-          {clienteSelecionado && (
-            <Grid size={12}>
-              <Typography variant="body2" color="text.secondary">
-                {clienteSelecionado.municipio} • {clienteSelecionado.area}
-              </Typography>
-            </Grid>
-          )}
         </Grid>
       </Paper>
 
-      {/* ── pH-metro ──────────────────────────────────────────────────────── */}
+      {/* ── Análises vinculadas ────────────────────────────────────────── */}
       <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          pH-metro
-        </Typography>
-        <Grid container spacing={2}>
-          {PH_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      {/* ── Espectrofotômetro ─────────────────────────────────────────────── */}
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Espectrofotômetro
-        </Typography>
-        <Grid container spacing={2}>
-          {ESPECTRO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      {/* ── Fotômetro de chama ────────────────────────────────────────────── */}
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Fotômetro de chama
-        </Typography>
-        <Grid container spacing={2}>
-          {FOTOMETRO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      {/* ── Absorção atômica ──────────────────────────────────────────────── */}
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Absorção atômica
-        </Typography>
-        <Grid container spacing={2}>
-          {ABSORCAO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      {/* ── Titulação ─────────────────────────────────────────────────────── */}
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Titulação
-        </Typography>
-        <Grid container spacing={2}>
-          {TITULACAO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      {/* ── Granulometria ─────────────────────────────────────────────────── */}
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Granulometria
-        </Typography>
-        <Grid container spacing={2}>
-          {GRANULOMETRIA_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          mb={2}
+        >
+          <Typography variant="subtitle1" fontWeight={700}>
+            Amostras ({analises.length})
+          </Typography>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<AddIcon />}
+            onClick={abrirDialog}
+          >
+            Nova Amostra
+          </Button>
+        </Stack>
+        <DataGrid
+          rows={analises}
+          columns={colunas}
+          loading={analisesLoading}
+          autoHeight
+          disableRowSelectionOnClick
+          pageSizeOptions={[10, 25, 50]}
+          initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+          sx={{
+            "& .MuiDataGrid-cell": { alignItems: "center", display: "flex" },
+          }}
+        />
       </Paper>
 
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2} mb={4}>
@@ -413,6 +459,155 @@ export default function LaudoEditPage() {
           {submitting ? "Salvando..." : "Salvar alterações"}
         </Button>
       </Stack>
+
+      <ConfirmDialog
+        open={confirmarRemocao !== null}
+        title="Remover análise"
+        message={`Deseja remover permanentemente a análise ${confirmarRemocao?.n_lab}?`}
+        confirmLabel="Remover"
+        loading={removendo !== null}
+        onConfirm={async () => {
+          if (confirmarRemocao) {
+            await remover(confirmarRemocao.id);
+            setConfirmarRemocao(null);
+          }
+        }}
+        onCancel={() => setConfirmarRemocao(null)}
+      />
+
+      {/* ── Dialog Editar Amostra ───────────────────────────────────────── */}
+      <Dialog
+        open={editandoAmostra !== null}
+        onClose={() => setEditandoAmostra(null)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>Editar Amostra</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} mt={1}>
+            <TextField
+              label="N° Lab *"
+              placeholder="2026/001"
+              size="small"
+              fullWidth
+              value={nLabEdit}
+              onChange={(e) => {
+                setNLabEdit(e.target.value);
+                setErroEdit("");
+              }}
+              error={!!erroEdit && erroEdit.includes("Formato")}
+              helperText={
+                erroEdit.includes("Formato") ? erroEdit : "Formato: AAAA/NNN"
+              }
+              inputProps={{ maxLength: 8 }}
+            />
+            <TextField
+              label="Referência"
+              placeholder="Identificação do produtor / talhão"
+              size="small"
+              fullWidth
+              value={referenciaEdit}
+              onChange={(e) => setReferenciaEdit(e.target.value)}
+            />
+            <TextField
+              label="Data de entrada *"
+              type="date"
+              size="small"
+              fullWidth
+              value={dataEntradaEdit}
+              onChange={(e) => {
+                setDataEntradaEdit(e.target.value);
+                setErroEdit("");
+              }}
+              slotProps={{ inputLabel: { shrink: true } }}
+              error={!!erroEdit && erroEdit.includes("Data")}
+              helperText={erroEdit.includes("Data") ? erroEdit : undefined}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditandoAmostra(null)}>Cancelar</Button>
+          <Button
+            variant="contained"
+            disabled={editando !== null}
+            onClick={() => void handleEditarAmostra()}
+          >
+            {editando !== null ? "Salvando..." : "Salvar"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ── Dialog Nova Amostra ─────────────────────────────────────────── */}
+      <Dialog
+        open={dialogAberto}
+        onClose={() => setDialogAberto(false)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>Nova Amostra</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} mt={1}>
+            <TextField
+              label="N° Lab *"
+              placeholder="2026/001"
+              size="small"
+              fullWidth
+              value={nLabNovo}
+              onChange={(e) => {
+                setNLabNovo(e.target.value);
+                setErroNLab("");
+              }}
+              error={!!erroNLab && erroNLab.includes("Formato")}
+              helperText={
+                erroNLab.includes("Formato") ? erroNLab : "Formato: AAAA/NNN"
+              }
+              inputProps={{ maxLength: 8 }}
+            />
+            <TextField
+              label="Referência"
+              placeholder="Identificação do produtor / talhão"
+              size="small"
+              fullWidth
+              value={referenciaNova}
+              onChange={(e) => setReferenciaNova(e.target.value)}
+            />
+            <TextField
+              label="Data de entrada *"
+              type="date"
+              size="small"
+              fullWidth
+              value={dataEntradaNova}
+              onChange={(e) => {
+                setDataEntradaNova(e.target.value);
+                setErroNLab("");
+              }}
+              slotProps={{ inputLabel: { shrink: true } }}
+              error={!!erroNLab && erroNLab.includes("Data")}
+              helperText={erroNLab.includes("Data") ? erroNLab : undefined}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogAberto(false)}>Cancelar</Button>
+          <Button
+            variant="contained"
+            disabled={salvando}
+            onClick={() => void handleCriarAmostra()}
+          >
+            {salvando ? "Salvando..." : "Adicionar"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ── Dialog Correção de Análise ──────────────────────────────────── */}
+      {analiseCorrecao && laudoId && (
+        <DialogCorrecaoAnalise
+          open={analiseCorrecao !== null}
+          laudoId={laudoId}
+          analiseId={analiseCorrecao.id}
+          onClose={() => setAnaliseCorrecao(null)}
+        />
+      )}
     </Box>
   );
 }

--- a/labas-web/src/pages/laudos/LaudoFormPage.tsx
+++ b/labas-web/src/pages/laudos/LaudoFormPage.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { Controller } from "react-hook-form";
-import type { InputHTMLAttributes } from "react";
 import {
-  Alert,
   Autocomplete,
   Box,
   Button,
@@ -18,81 +16,6 @@ import LoadingOverlay from "../../components/shared/LoadingOverlay";
 import { useLaudoForm } from "../../hooks/useLaudoForm";
 import { useClientes } from "../../hooks/useClientes";
 import type { Cliente } from "../../types/cliente";
-import type { LaudoForm } from "../../schemas/laudoSchemas";
-
-const decimalInputProps = {
-  inputMode: "decimal" as const,
-  pattern: "[0-9]*[.,]?[0-9]*",
-};
-
-type FieldName = keyof LaudoForm;
-
-type FieldConfig = {
-  name: FieldName;
-  label: string;
-  inputProps?: InputHTMLAttributes<HTMLInputElement>;
-};
-
-const PH_FIELDS: FieldConfig[] = [
-  { name: "ph_agua", label: "pH água" },
-  { name: "ph_cacl2", label: "pH CaCl₂" },
-  { name: "ph_kcl", label: "pH KCl" },
-];
-
-const ESPECTRO_FIELDS: FieldConfig[] = [
-  { name: "p_m", label: "P Mehlich (mg/dm³)" },
-  { name: "p_r", label: "P Resina (mg/dm³)" },
-  { name: "p_rem", label: "P Rem (mg/L)" },
-  { name: "mo", label: "Matéria Orgânica (dag/kg)" },
-  { name: "s", label: "Enxofre (mg/dm³)" },
-  { name: "b", label: "Boro (mg/dm³)" },
-];
-
-const FOTOMETRO_FIELDS: FieldConfig[] = [
-  { name: "k", label: "Potássio (mg/dm³)" },
-  { name: "na", label: "Sódio (mg/dm³)" },
-];
-
-const ABSORCAO_FIELDS: FieldConfig[] = [
-  { name: "ca", label: "Cálcio (cmolc/dm³)" },
-  { name: "mg", label: "Magnésio (cmolc/dm³)" },
-  { name: "cu", label: "Cobre (mg/dm³)" },
-  { name: "fe", label: "Ferro (mg/dm³)" },
-  { name: "mn", label: "Manganês (mg/dm³)" },
-  { name: "zn", label: "Zinco (mg/dm³)" },
-];
-
-const TITULACAO_FIELDS: FieldConfig[] = [
-  { name: "al", label: "Alumínio (cmolc/dm³)" },
-  { name: "h_al", label: "Acidez Potencial (cmolc/dm³)" },
-];
-
-const GRANULOMETRIA_FIELDS: FieldConfig[] = [
-  { name: "areia", label: "Areia (%)" },
-  { name: "argila", label: "Argila (%)" },
-  { name: "silte", label: "Silte (%)" },
-];
-
-const renderNumberField = (
-  field: FieldConfig,
-  getErrorMessage: (name: FieldName) => string | undefined,
-  register: ReturnType<typeof useLaudoForm>["form"]["register"],
-  disabled: boolean,
-) => (
-  <Grid size={{ xs: 12, sm: 6, md: 4 }} key={field.name}>
-    <TextField
-      fullWidth
-      size="small"
-      label={field.label}
-      type="text"
-      inputProps={field.inputProps ?? decimalInputProps}
-      error={!!getErrorMessage(field.name)}
-      helperText={getErrorMessage(field.name)}
-      disabled={disabled}
-      {...register(field.name)}
-    />
-  </Grid>
-);
 
 export default function LaudoFormPage() {
   const { form, submitting, onSubmit } = useLaudoForm();
@@ -101,9 +24,6 @@ export default function LaudoFormPage() {
     null,
   );
   const [clienteInput, setClienteInput] = useState("");
-
-  const getErrorMessage = (name: FieldName) =>
-    form.formState.errors[name]?.message as string | undefined;
 
   const handleClienteInput = (_: React.SyntheticEvent, value: string) => {
     setClienteInput(value);
@@ -125,78 +45,20 @@ export default function LaudoFormPage() {
     buscar(value);
   };
 
-  const handleClienteChange = (
-    _: React.SyntheticEvent,
-    value: Cliente | null,
-  ) => {
-    setClienteSelecionado(value);
-  };
-
   return (
     <Box component="form" onSubmit={onSubmit} noValidate>
       <LoadingOverlay open={submitting} message="Salvando laudo..." />
 
       <PageHeader
         title="Novo Laudo"
-        subtitle="Cadastro completo das análises da amostra"
+        subtitle="Informe o cliente e a data de entrada. As análises são adicionadas depois."
       />
-
-      <Alert severity="info" sx={{ mb: 3 }}>
-        Crie o laudo com no mínimo <strong>Nº do laudo</strong> e{" "}
-        <strong>Cliente</strong>. Os valores químicos podem ser deixados em
-        branco e preenchidos depois via <strong>Operação em Lote</strong>.
-        Campos calculados (SB, CTC, V%, m%) são preenchidos automaticamente pelo
-        sistema.
-      </Alert>
 
       <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
         <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Dados gerais
+          Dados do laudo
         </Typography>
         <Grid container spacing={2}>
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <TextField
-              fullWidth
-              size="small"
-              label="Nº do laudo"
-              placeholder="2026/001"
-              error={!!getErrorMessage("n_lab")}
-              helperText={
-                getErrorMessage("n_lab") ?? "Formato: AAAA/NNN — ex: 2026/001"
-              }
-              disabled={submitting}
-              {...form.register("n_lab")}
-            />
-          </Grid>
-
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <TextField
-              fullWidth
-              size="small"
-              label="Data de entrada"
-              type="date"
-              InputLabelProps={{ shrink: true }}
-              error={!!getErrorMessage("data_entrada")}
-              helperText={getErrorMessage("data_entrada")}
-              disabled={submitting}
-              {...form.register("data_entrada")}
-            />
-          </Grid>
-
-          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-            <TextField
-              fullWidth
-              size="small"
-              label="Data de saída"
-              type="date"
-              InputLabelProps={{ shrink: true }}
-              error={!!getErrorMessage("data_saida")}
-              helperText={getErrorMessage("data_saida")}
-              disabled={submitting}
-              {...form.register("data_saida")}
-            />
-          </Grid>
-
           <Grid size={{ xs: 12, md: 8 }}>
             <Controller
               control={form.control}
@@ -207,8 +69,8 @@ export default function LaudoFormPage() {
                   value={clienteSelecionado}
                   inputValue={clienteInput}
                   onInputChange={handleClienteInput}
-                  onChange={(event, value) => {
-                    handleClienteChange(event, value);
+                  onChange={(_, value) => {
+                    setClienteSelecionado(value);
                     field.onChange(value?.codigo ?? "");
                   }}
                   onBlur={field.onBlur}
@@ -227,7 +89,7 @@ export default function LaudoFormPage() {
                   renderInput={(params) => (
                     <TextField
                       {...params}
-                      label="Cliente"
+                      label="Cliente *"
                       size="small"
                       error={!!fieldState.error}
                       helperText={fieldState.error?.message}
@@ -238,14 +100,17 @@ export default function LaudoFormPage() {
             />
           </Grid>
 
-          <Grid size={{ xs: 12, md: 4 }}>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
             <TextField
               fullWidth
               size="small"
-              label="Código do cliente"
-              value={clienteSelecionado?.codigo ?? ""}
-              InputProps={{ readOnly: true }}
-              placeholder="Selecione um cliente"
+              label="Data de Entrada *"
+              type="date"
+              slotProps={{ inputLabel: { shrink: true } }}
+              error={!!form.formState.errors.data_emissao}
+              helperText={form.formState.errors.data_emissao?.message}
+              disabled={submitting}
+              {...form.register("data_emissao")}
             />
           </Grid>
 
@@ -256,102 +121,18 @@ export default function LaudoFormPage() {
               </Typography>
             </Grid>
           )}
-        </Grid>
-      </Paper>
 
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          pH-metro
-        </Typography>
-        <Grid container spacing={2}>
-          {PH_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Espectrofotômetro
-        </Typography>
-        <Grid container spacing={2}>
-          {ESPECTRO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Fotômetro de chama
-        </Typography>
-        <Grid container spacing={2}>
-          {FOTOMETRO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Absorção atômica
-        </Typography>
-        <Grid container spacing={2}>
-          {ABSORCAO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Titulação
-        </Typography>
-        <Grid container spacing={2}>
-          {TITULACAO_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
-        </Grid>
-      </Paper>
-
-      <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
-        <Typography variant="subtitle1" fontWeight={700} mb={2}>
-          Granulometria
-        </Typography>
-        <Grid container spacing={2}>
-          {GRANULOMETRIA_FIELDS.map((field) =>
-            renderNumberField(
-              field,
-              getErrorMessage,
-              form.register,
-              submitting,
-            ),
-          )}
+          <Grid size={12}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Observações"
+              multiline
+              rows={3}
+              disabled={submitting}
+              {...form.register("observacoes")}
+            />
+          </Grid>
         </Grid>
       </Paper>
 
@@ -360,7 +141,7 @@ export default function LaudoFormPage() {
           Voltar
         </Button>
         <Button type="submit" variant="contained" disabled={submitting}>
-          {submitting ? "Salvando..." : "Salvar laudo"}
+          {submitting ? "Salvando..." : "Criar laudo"}
         </Button>
       </Stack>
     </Box>

--- a/labas-web/src/pages/laudos/LaudosPage.tsx
+++ b/labas-web/src/pages/laudos/LaudosPage.tsx
@@ -21,6 +21,7 @@ import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
+import VisibilityIcon from "@mui/icons-material/Visibility";
 import SearchIcon from "@mui/icons-material/Search";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
@@ -34,18 +35,20 @@ export default function LaudosPage() {
   const { laudos, loading, deletando, baixarPdf, excluir } = useLaudos();
 
   const [filtro, setFiltro] = useState("");
-  const [confirmarExclusao, setConfirmarExclusao] = useState<string | null>(
+  const [confirmarExclusao, setConfirmarExclusao] = useState<number | null>(
     null,
   );
 
   const laudosFiltrados = laudos.filter((l) => {
     const termo = filtro.toLowerCase();
     return (
-      l.n_lab.toLowerCase().includes(termo) ||
+      l.codigo_laudo.toLowerCase().includes(termo) ||
       l.cliente.nome.toLowerCase().includes(termo) ||
       l.cliente.codigo.toLowerCase().includes(termo)
     );
   });
+
+  const laudoParaExcluir = laudos.find((l) => l.id === confirmarExclusao);
 
   if (loading) {
     return (
@@ -76,16 +79,18 @@ export default function LaudosPage() {
       >
         <TextField
           size="small"
-          placeholder="Filtrar por N° Lab ou cliente..."
+          placeholder="Filtrar por código ou cliente..."
           value={filtro}
           onChange={(e) => setFiltro(e.target.value)}
           sx={{ minWidth: 280 }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            },
           }}
         />
 
@@ -111,19 +116,18 @@ export default function LaudosPage() {
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell>N° Lab</TableCell>
+                <TableCell>Código</TableCell>
                 <TableCell>Cliente</TableCell>
-                <TableCell>Data Entrada</TableCell>
-                <TableCell>Data Saída</TableCell>
+                <TableCell>Data Emissão</TableCell>
                 <TableCell align="right">Ações</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {laudosFiltrados.map((laudo) => (
-                <TableRow key={laudo.n_lab} hover>
+                <TableRow key={laudo.id} hover>
                   <TableCell>
                     <Typography variant="body2" fontWeight={600}>
-                      {laudo.n_lab}
+                      {laudo.codigo_laudo}
                     </Typography>
                   </TableCell>
                   <TableCell>
@@ -134,14 +138,24 @@ export default function LaudosPage() {
                       {laudo.cliente.codigo}
                     </Typography>
                   </TableCell>
-                  <TableCell>{laudo.data_entrada}</TableCell>
-                  <TableCell>{laudo.data_saida ?? "—"}</TableCell>
+                  <TableCell>{laudo.data_emissao}</TableCell>
                   <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
+                    <Tooltip title="Ver detalhe">
+                      <IconButton
+                        size="small"
+                        onClick={() => navigate(`/laudos/${laudo.id}`)}
+                      >
+                        <VisibilityIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+
                     <Tooltip title="Baixar PDF">
                       <IconButton
                         size="small"
                         color="primary"
-                        onClick={() => baixarPdf(laudo.n_lab)}
+                        onClick={() =>
+                          void baixarPdf(laudo.id, laudo.codigo_laudo)
+                        }
                       >
                         <PictureAsPdfIcon fontSize="small" />
                       </IconButton>
@@ -153,9 +167,7 @@ export default function LaudosPage() {
                           <IconButton
                             size="small"
                             onClick={() =>
-                              navigate(
-                                `/laudos/${encodeURIComponent(laudo.n_lab)}/editar`,
-                              )
+                              navigate(`/laudos/${laudo.id}/editar`)
                             }
                           >
                             <EditIcon fontSize="small" />
@@ -166,8 +178,8 @@ export default function LaudosPage() {
                           <IconButton
                             size="small"
                             color="error"
-                            disabled={deletando === laudo.n_lab}
-                            onClick={() => setConfirmarExclusao(laudo.n_lab)}
+                            disabled={deletando === laudo.id}
+                            onClick={() => setConfirmarExclusao(laudo.id)}
                           >
                             <DeleteIcon fontSize="small" />
                           </IconButton>
@@ -185,11 +197,11 @@ export default function LaudosPage() {
       <ConfirmDialog
         open={confirmarExclusao !== null}
         title="Excluir laudo"
-        message={`Deseja excluir permanentemente o laudo ${confirmarExclusao}? Esta ação não pode ser desfeita.`}
+        message={`Deseja excluir permanentemente o laudo ${laudoParaExcluir?.codigo_laudo ?? ""}? Esta ação não pode ser desfeita.`}
         confirmLabel="Excluir"
         loading={deletando !== null}
         onConfirm={async () => {
-          if (confirmarExclusao) {
+          if (confirmarExclusao !== null) {
             await excluir(confirmarExclusao);
             setConfirmarExclusao(null);
           }

--- a/labas-web/src/pages/operacao-lote/EntradaLotePage.tsx
+++ b/labas-web/src/pages/operacao-lote/EntradaLotePage.tsx
@@ -257,7 +257,7 @@ export default function EntradaLotePage() {
   return (
     <Box>
       <PageHeader
-        title="Operação em Lote"
+        title="Amostras"
         subtitle="Bancada de digitação de leituras brutas por elemento"
       />
 

--- a/labas-web/src/schemas/analiseSchemas.ts
+++ b/labas-web/src/schemas/analiseSchemas.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data inválida");
+const optionalDate = z.union([dateSchema, z.literal("")]);
+
+const nullableNumber = z
+  .union([z.coerce.number(), z.literal("")])
+  .transform((value) => (value === "" ? null : value));
+
+/** Schema para criar/editar uma AnaliseSolo vinculada a um Laudo. */
+export const analiseSchema = z.object({
+  n_lab: z
+    .string()
+    .min(1, "N° do laudo é obrigatório")
+    .regex(/^\d{4}\/\d{3}$/, "Use o formato AAAA/NNN"),
+  referencia: z.string().optional(),
+  data_entrada: dateSchema,
+  data_saida: optionalDate,
+  ativo: z.boolean().default(true),
+  ph_agua: nullableNumber.optional(),
+  ph_cacl2: nullableNumber.optional(),
+  ph_kcl: nullableNumber.optional(),
+  p_m: nullableNumber.optional(),
+  p_r: nullableNumber.optional(),
+  p_rem: nullableNumber.optional(),
+  mo: nullableNumber.optional(),
+  s: nullableNumber.optional(),
+  b: nullableNumber.optional(),
+  k: nullableNumber.optional(),
+  na: nullableNumber.optional(),
+  ca: nullableNumber.optional(),
+  mg: nullableNumber.optional(),
+  cu: nullableNumber.optional(),
+  fe: nullableNumber.optional(),
+  mn: nullableNumber.optional(),
+  zn: nullableNumber.optional(),
+  al: nullableNumber.optional(),
+  h_al: nullableNumber.optional(),
+  areia: nullableNumber.optional(),
+  argila: nullableNumber.optional(),
+  silte: nullableNumber.optional(),
+});
+
+export type AnaliseFormInput = z.input<typeof analiseSchema>;
+export type AnaliseForm = z.output<typeof analiseSchema>;

--- a/labas-web/src/schemas/laudoSchemas.ts
+++ b/labas-web/src/schemas/laudoSchemas.ts
@@ -1,44 +1,18 @@
 import { z } from "zod";
 
 const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Data inválida");
-
-const nullableNumber = z
-  .union([z.coerce.number(), z.literal("")])
-  .transform((value) => (value === "" ? null : value));
-
 const optionalDate = z.union([dateSchema, z.literal("")]);
 
+/** Schema do cabeçalho do Laudo (sem campos de análise). */
 export const laudoSchema = z.object({
-  n_lab: z
-    .string()
-    .min(1, "Nº do laudo é obrigatório")
-    .regex(/^\d{4}\/\d{3}$/, "Use o formato AAAA/NNN"),
   cliente_codigo: z.string().min(1, "Cliente é obrigatório"),
-  data_entrada: dateSchema,
-  data_saida: optionalDate,
-  ph_agua: nullableNumber.optional(),
-  ph_cacl2: nullableNumber.optional(),
-  ph_kcl: nullableNumber.optional(),
-  p_m: nullableNumber.optional(),
-  p_r: nullableNumber.optional(),
-  p_rem: nullableNumber.optional(),
-  mo: nullableNumber.optional(),
-  s: nullableNumber.optional(),
-  b: nullableNumber.optional(),
-  k: nullableNumber.optional(),
-  na: nullableNumber.optional(),
-  ca: nullableNumber.optional(),
-  mg: nullableNumber.optional(),
-  cu: nullableNumber.optional(),
-  fe: nullableNumber.optional(),
-  mn: nullableNumber.optional(),
-  zn: nullableNumber.optional(),
-  al: nullableNumber.optional(),
-  h_al: nullableNumber.optional(),
-  areia: nullableNumber.optional(),
-  argila: nullableNumber.optional(),
-  silte: nullableNumber.optional(),
+  data_emissao: dateSchema,
+  data_saida: optionalDate.optional(),
+  observacoes: z.string().optional(),
 });
 
 export type LaudoFormInput = z.input<typeof laudoSchema>;
 export type LaudoForm = z.output<typeof laudoSchema>;
+
+// Reexporta para conveniência de imports já existentes
+export { optionalDate, dateSchema };

--- a/labas-web/src/services/analiseService.ts
+++ b/labas-web/src/services/analiseService.ts
@@ -1,0 +1,55 @@
+import { api } from "./api";
+import type { AnaliseSolo, AnaliseSoloPayload } from "../types/analise";
+
+const base = (laudoId: number) => `/laudos/${laudoId}/analises/`;
+
+export const analiseService = {
+  async listar(laudoId: number): Promise<AnaliseSolo[]> {
+    const { data } = await api.get<AnaliseSolo[]>(base(laudoId));
+    return data;
+  },
+
+  async buscar(laudoId: number, analiseId: number): Promise<AnaliseSolo> {
+    const { data } = await api.get<AnaliseSolo>(
+      `${base(laudoId)}${analiseId}/`,
+    );
+    return data;
+  },
+
+  async criar(
+    laudoId: number,
+    payload: Partial<AnaliseSoloPayload>,
+  ): Promise<AnaliseSolo> {
+    const { data } = await api.post<AnaliseSolo>(base(laudoId), payload);
+    return data;
+  },
+
+  async atualizar(
+    laudoId: number,
+    analiseId: number,
+    payload: Partial<AnaliseSoloPayload>,
+  ): Promise<AnaliseSolo> {
+    const { data } = await api.patch<AnaliseSolo>(
+      `${base(laudoId)}${analiseId}/`,
+      payload,
+    );
+    return data;
+  },
+
+  async remover(laudoId: number, analiseId: number): Promise<void> {
+    await api.delete(`${base(laudoId)}${analiseId}/`);
+  },
+
+  /** Alterna o flag ativo de uma análise (staff only). */
+  async toggleAtivo(
+    laudoId: number,
+    analiseId: number,
+    ativo: boolean,
+  ): Promise<AnaliseSolo> {
+    const { data } = await api.patch<AnaliseSolo>(
+      `${base(laudoId)}${analiseId}/`,
+      { ativo },
+    );
+    return data;
+  },
+};

--- a/labas-web/src/services/correcaoService.ts
+++ b/labas-web/src/services/correcaoService.ts
@@ -1,0 +1,24 @@
+import { api } from "./api";
+import type { LeituraDetalhe, LeituraCorrecaoPayload } from "../types/analise";
+
+export const correcaoService = {
+  /** Lista todas as leituras brutas registradas para uma AnaliseSolo. */
+  async listarLeituras(analiseId: number): Promise<LeituraDetalhe[]> {
+    const { data } = await api.get<LeituraDetalhe[]>(
+      `/analises/${analiseId}/leituras/`,
+    );
+    return data;
+  },
+
+  /** Corrige leitura_bruta e/ou fator_diluicao; backend re-dispara o signal. */
+  async corrigirLeitura(
+    leituraId: number,
+    payload: LeituraCorrecaoPayload,
+  ): Promise<LeituraDetalhe> {
+    const { data } = await api.patch<LeituraDetalhe>(
+      `/leituras/${leituraId}/`,
+      payload,
+    );
+    return data;
+  },
+};

--- a/labas-web/src/services/laudoService.ts
+++ b/labas-web/src/services/laudoService.ts
@@ -1,77 +1,40 @@
 import { api } from "./api";
-import type {
-  AnaliseSolo,
-  AnaliseSoloPayload,
-  PaginatedResponse,
-} from "../types/analise";
+import type { Laudo, LaudoPayload, PaginatedResponse } from "../types/analise";
 
-const BASE = "/meus-laudos/";
-
-const normalizarNLab = (nLab: string) => nLab.replace(/^\/+|\/+$/g, "");
+const BASE = "/laudos/";
 
 export const laudoService = {
-  /** Lista laudos com paginação padrão do DRF. */
-  async listar(page?: number): Promise<PaginatedResponse<AnaliseSolo>> {
+  async listar(page?: number): Promise<PaginatedResponse<Laudo>> {
     const { data } = await api.get(BASE, {
       params: page ? { page } : undefined,
     });
     if (Array.isArray(data)) {
       return { count: data.length, next: null, previous: null, results: data };
     }
-    return data as PaginatedResponse<AnaliseSolo>;
+    return data as PaginatedResponse<Laudo>;
   },
 
-  /** Lista os laudos do cliente logado (rota /meus-laudos/). */
-  async listarMeusLaudos(): Promise<PaginatedResponse<AnaliseSolo>> {
-    const { data } = await api.get(BASE);
-    if (Array.isArray(data)) {
-      return { count: data.length, next: null, previous: null, results: data };
-    }
-    return data as PaginatedResponse<AnaliseSolo>;
-  },
-
-  /** Cria um novo laudo (somente staff). */
-  async criar(payload: AnaliseSoloPayload): Promise<AnaliseSolo> {
-    const { data } = await api.post<AnaliseSolo>(BASE, payload);
+  async buscar(id: number): Promise<Laudo> {
+    const { data } = await api.get<Laudo>(`${BASE}${id}/`);
     return data;
   },
 
-  /** Busca detalhe de um laudo pelo N Lab. */
-  async buscar(nLab: string): Promise<AnaliseSolo> {
-    const { data } = await api.get<AnaliseSolo>(
-      `${BASE}${normalizarNLab(nLab)}/`,
-    );
+  async criar(payload: LaudoPayload): Promise<Laudo> {
+    const { data } = await api.post<Laudo>(BASE, payload);
     return data;
   },
 
-  /** Atualiza parcialmente um laudo (somente staff). */
-  async atualizar(
-    nLab: string,
-    payload: Partial<AnaliseSoloPayload>,
-  ): Promise<AnaliseSolo> {
-    const { data } = await api.patch<AnaliseSolo>(
-      `${BASE}${normalizarNLab(nLab)}/`,
-      payload,
-    );
+  async atualizar(id: number, payload: Partial<LaudoPayload>): Promise<Laudo> {
+    const { data } = await api.patch<Laudo>(`${BASE}${id}/`, payload);
     return data;
   },
 
-  /** Remove um laudo (somente staff). */
-  async remover(nLab: string): Promise<void> {
-    await api.delete(`${BASE}${normalizarNLab(nLab)}/`);
+  async remover(id: number): Promise<void> {
+    await api.delete(`${BASE}${id}/`);
   },
 
-  /** Gera o PDF oficial do laudo. */
-  async baixarPdf(nLab: string): Promise<Blob> {
-    const { data } = await api.get(`${BASE}${normalizarNLab(nLab)}/pdf/`, {
-      responseType: "blob",
-    });
-    return data as Blob;
-  },
-
-  /** Baixa o PDF do laudo do cliente logado. */
-  async baixarPdfLaudo(nLab: string): Promise<Blob> {
-    const { data } = await api.get(`${BASE}${normalizarNLab(nLab)}/pdf/`, {
+  async baixarPdf(id: number): Promise<Blob> {
+    const { data } = await api.get(`${BASE}${id}/pdf/`, {
       responseType: "blob",
     });
     return data as Blob;

--- a/labas-web/src/types/analise.ts
+++ b/labas-web/src/types/analise.ts
@@ -1,150 +1,118 @@
 import type { Cliente } from "./cliente";
 
-/**
- * Representa uma análise de solo completa, espelhando o model `AnaliseSolo` do Django.
- *
- * Campos agrupados por equipamento de origem:
- * - pH-metro: ph_agua, ph_cacl2, ph_kcl
- * - Espectrofotômetro: p_m, p_r, p_rem, mo, s, b
- * - Fotômetro de Chama: k, na
- * - Absorção Atômica: ca, mg, cu, fe, mn, zn
- * - Titulação: al, h_al
- * - Granulometria: areia, argila, silte
- *
- * Campos calculados automaticamente pelo backend (somente leitura no frontend):
- * sb, t, T_maiusculo, V, m, ca_mg, ca_k, mg_k, c_org
- */
-export interface AnaliseSolo {
-  /** Identificador do laudo no formato "ANO/NNN" — ex: "2026/001" */
-  n_lab: string;
+// ─── Resposta paginada DRF ────────────────────────────────────────────────────
 
-  /** Cliente (produtor rural) vinculado à amostra */
+export interface PaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}
+
+// ─── Laudo (cabeçalho) ────────────────────────────────────────────────────────
+
+/** Cabeçalho do documento entregue ao cliente. Pai de N análises. */
+export interface Laudo {
+  id: number;
+  /** Código gerado pelo backend: "L-AAAA/N" — read-only */
+  codigo_laudo: string;
   cliente: Cliente;
+  /** Usado apenas no payload de criação/edição */
+  cliente_codigo?: string;
+  /** Data de entrada das amostras no laboratório */
+  data_emissao: string;
+  /** Data de saída (laudo disponível ao cliente) — nullable */
+  data_saida: string | null;
+  observacoes: string | null;
+}
 
-  /** Data de entrada da amostra no laboratório (formato ISO: "YYYY-MM-DD") */
+export type LaudoPayload = {
+  cliente_codigo: string;
+  data_emissao: string;
+  data_saida?: string | null;
+  observacoes?: string | null;
+};
+
+// ─── AnaliseSolo (amostra individual, filho de Laudo) ─────────────────────────
+
+export interface AnaliseSolo {
+  id: number;
+  laudo_id: number;
+  n_lab: string;
+  ativo: boolean;
+  referencia: string | null;
   data_entrada: string;
-
-  /** Data de conclusão do laudo. Null enquanto ainda em análise */
   data_saida: string | null;
 
-  // ─── pH-metro ────────────────────────────────────────────────────────────────
-
-  /** pH em água */
+  // pH-metro
   ph_agua: number | null;
-
-  /** pH em solução de CaCl₂ */
   ph_cacl2: number | null;
-
-  /** pH em solução de KCl */
   ph_kcl: number | null;
 
-  // ─── Espectrofotômetro ────────────────────────────────────────────────────────
-
-  /** Fósforo extraído pelo método Mehlich (mg/dm³) */
+  // Espectrofotômetro
   p_m: number | null;
-
-  /** Fósforo extraído pelo método Resina (mg/dm³) */
   p_r: number | null;
-
-  /** Fósforo Remanescente — indica capacidade de adsorção do solo (mg/L) */
   p_rem: number | null;
-
-  /** Matéria Orgânica (g/kg) */
   mo: number | null;
-
-  /** Enxofre (mg/dm³) */
   s: number | null;
-
-  /** Boro (mg/dm³) */
   b: number | null;
 
-  // ─── Fotômetro de Chama ───────────────────────────────────────────────────────
-
-  /** Potássio (cmolc/dm³) */
+  // Fotômetro de Chama
   k: number | null;
-
-  /** Sódio (mg/dm³) */
   na: number | null;
 
-  // ─── Absorção Atômica ─────────────────────────────────────────────────────────
-
-  /** Cálcio (cmolc/dm³) */
+  // Absorção Atômica
   ca: number | null;
-
-  /** Magnésio (cmolc/dm³) */
   mg: number | null;
-
-  /** Cobre (mg/dm³) */
   cu: number | null;
-
-  /** Ferro (mg/dm³) */
   fe: number | null;
-
-  /** Manganês (mg/dm³) */
   mn: number | null;
-
-  /** Zinco (mg/dm³) */
   zn: number | null;
 
-  // ─── Titulação ────────────────────────────────────────────────────────────────
-
-  /** Alumínio trocável (cmolc/dm³) */
+  // Titulação
   al: number | null;
-
-  /** Acidez Potencial — Hidrogênio + Alumínio (cmolc/dm³) */
   h_al: number | null;
 
-  // ─── Granulometria ────────────────────────────────────────────────────────────
-
-  /** Areia (g/kg) */
+  // Granulometria
   areia: number | null;
-
-  /** Argila (g/kg) */
   argila: number | null;
-
-  /** Silte (g/kg) */
   silte: number | null;
 
-  // ─── Calculados pelo backend (read-only no frontend) ─────────────────────────
-
-  /** Soma de Bases: Ca + Mg + K + Na (cmolc/dm³) */
+  // Calculados pelo backend (read-only)
   sb: number | null;
-
-  /** CTC Efetiva: SB + Al (cmolc/dm³) */
   t: number | null;
-
-  /** CTC a pH 7,0: SB + H+Al (cmolc/dm³) */
   T_maiusculo: number | null;
-
-  /** Saturação por Bases: (SB / T) × 100 (%) */
   V: number | null;
-
-  /** Saturação por Alumínio: (Al / t) × 100 (%) */
   m: number | null;
-
-  /** Relação Ca/Mg */
   ca_mg: number | null;
-
-  /** Relação Ca/K */
   ca_k: number | null;
-
-  /** Relação Mg/K */
   mg_k: number | null;
-
-  /** Carbono Orgânico (g/kg) */
   c_org: number | null;
 }
 
-/**
- * Payload para criação e edição de laudos via API.
- *
- * Remove os campos calculados pelo backend (somente leitura) e
- * substitui o objeto `cliente` pelo código do cliente (`cliente_codigo`),
- * conforme esperado pelo serializer do Django.
- */
-export type AnaliseSoloPayload = Omit<
-  AnaliseSolo,
-  | "cliente"
+// ─── LeituraEquipamento (bancada) ─────────────────────────────────────────────
+
+/** Leitura bruta de um elemento registrada na bancada, com resultado calculado. */
+export interface LeituraDetalhe {
+  id: number;
+  bateria: number;
+  elemento: string; // ex: "Ca", "Mg", "K"
+  elemento_display: string; // ex: "Cálcio", "Magnésio"
+  equipamento: string; // ex: "AA", "FC"
+  leitura_bruta: number;
+  fator_diluicao: number | null;
+  resultado_calculado: number | null;
+}
+
+export type LeituraCorrecaoPayload = {
+  leitura_bruta: number;
+  fator_diluicao?: number | null;
+};
+
+/** Campos calculados — nunca enviados no payload. */
+type CamposCalculados =
+  | "id"
+  | "laudo_id"
   | "sb"
   | "t"
   | "T_maiusculo"
@@ -153,16 +121,6 @@ export type AnaliseSoloPayload = Omit<
   | "ca_mg"
   | "ca_k"
   | "mg_k"
-  | "c_org"
-> & {
-  /** Código do cliente — substitui o objeto `cliente` no payload de envio */
-  cliente_codigo: string;
-};
+  | "c_org";
 
-/** Resposta paginada padrão do DRF. */
-export interface PaginatedResponse<T> {
-  count: number;
-  next: string | null;
-  previous: string | null;
-  results: T[];
-}
+export type AnaliseSoloPayload = Omit<AnaliseSolo, CamposCalculados>;


### PR DESCRIPTION
## Sprint 8 — Roteiro de Execução + Correção de Análises

### Backend
- `Laudo.data_saida`: migration 0019 (nullable DateField)
- `LeiturasPorAnaliseListView`: `GET /api/analises/:id/leituras/`
- `LeituraEquipamentoDetailView`: `GET|PATCH /api/leituras/:id/` (re-dispara signal)
- `LeituraEquipamentoDetalheSerializer`: expõe elemento, equipamento, resultado_calculado
- `AnaliseSoloListCreateView`: `pagination_class = None` (fix spread error)

### Frontend
- Fluxo de criação de laudo redireciona para `/laudos/:id/editar`
- Sidebar: item "Amostras" + botão "Ir para Amostras" em LaudoEditPage
- `data_emissao` relabelado para "Data de Entrada"; campo "Data de Saída" adicionado
- Dialog de edição de ficha (n_lab, referencia, data_entrada) via `EditIcon`
- `DialogCorrecaoAnalise`: aba Bancada (PATCH /leituras/:id/) + aba Granulometria
- `correcaoService.ts`, `useCorrecaoAnalise.ts`, `analiseService.buscar()`

Closes nenhuma issue — entrega Sprint 8.