### PR TITLE
feat(dashboard): Sprint 9 — Dashboard interativo do técnico + Guia de Uso

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 > **Tech Lead:** Gabriel Azevedo | **Dev:** Sabrina  
 > **Stack:** React 19 + TypeScript + MUI v7 + React Hook Form + Zod + Axios  
 > **API:** Django REST Framework + JWT (SimpleJWT) — `http://localhost:8000/api/`  
-> **Última atualização:** 07/04/2026
+> **Última atualização:** 07/04/2026 — Sprint 9 adicionada
 
 ---
 
@@ -330,6 +330,53 @@ Em seguida, garanta que a palavra `node_modules/` está escrita dentro do seu ar
     - `GET|PATCH /api/leituras/:id/` → `LeituraEquipamentoDetailView`
     - `LeituraEquipamentoDetalheSerializer`: expõe `elemento`, `elemento_display`, `equipamento`, `resultado_calculado`
   - **Novos arquivos frontend:** `src/types/analise.ts` (`LeituraDetalhe`, `LeituraCorrecaoPayload`); `src/services/correcaoService.ts`; `src/hooks/useCorrecaoAnalise.ts`; `src/services/analiseService.ts` + método `buscar(laudoId, analiseId)`
+- ⬜ **Sprint 9 — Dashboard do Técnico + Guia de Uso** — branch `feat/gabriel/staff-dashboard`
+
+  > Objetivo: substituir o `DashboardPlaceholder` do staff por um painel interativo com KPIs do laboratório e uma página de guia de uso do sistema.
+
+  ***
+
+  #### Bloco 1 — Infraestrutura de Dados (Tipos e Services)
+
+  **Novos endpoints de backend necessários:**
+  - `GET /api/dashboard/stats/` → retorna KPIs agregados: total de laudos, laudos do mês, total de amostras, amostras do mês, total de clientes, baterias ativas
+  - `GET /api/dashboard/laudos-recentes/` → últimos 5 laudos criados (id, codigo_laudo, cliente_nome, data_emissao, total_analises)
+
+  **Arquivos frontend:**
+  - `src/types/dashboard.ts` — interfaces `DashboardStats` e `LaudoResumo`
+  - `src/services/dashboardService.ts` — `buscarStats(): Promise<DashboardStats>` e `buscarLaudosRecentes(): Promise<LaudoResumo[]>`
+
+  ***
+
+  #### Bloco 2 — Lógica e Estado (Hooks)
+
+  **Arquivos frontend:**
+  - `src/hooks/useDashboardStats.ts` — chama `dashboardService.buscarStats()`, expõe `stats`, `loading`, `erro`
+  - `src/hooks/useDashboardLaudos.ts` — chama `dashboardService.buscarLaudosRecentes()`, expõe `laudos`, `loading`, `erro`
+
+  _Sem schemas Zod neste bloco (dados são somente leitura, sem formulários)._
+
+  ***
+
+  #### Bloco 3 — Interface de Usuário (UI)
+
+  **Arquivos frontend:**
+  - `src/pages/dashboard/StaffDashboard.tsx` — painel principal do técnico:
+    - **Faixa de KPIs** (6 cards MUI com ícones): Laudos Totais, Laudos este Mês, Amostras Totais, Amostras este Mês, Clientes Cadastrados, Baterias Ativas
+    - **Tabela de Laudos Recentes**: últimos 5 laudos com link direto para `/laudos/:id`
+    - **Ações Rápidas**: botões de atalho — "Novo Laudo", "Nova Calibração", "Entrada de Amostras"
+  - `src/pages/dashboard/GuidePage.tsx` — rota `/guia` (privada, acessível a todos os perfis):
+    - Layout em abas MUI (`Tabs`) com seções: **Visão Geral**, **Calibração**, **Entrada de Amostras**, **Laudos**, **Clientes**
+    - Cada seção contém: descrição do módulo, fluxo passo a passo numerado, dicas de uso e capturas de tela (placeholders com `<Box sx={{ bgcolor: 'grey.200' }}>`)
+  - `src/pages/dashboard/DashboardPlaceholder.tsx` — atualizado: staff renderiza `<StaffDashboard />`, cliente mantém `<ClientDashboard />`
+  - `src/App.tsx` — adicionar rota `/guia` com lazy import de `GuidePage`
+  - **Sidebar** — adicionar item "Guia de Uso" com `MenuBookIcon` → `/guia` (visível para todos os perfis autenticados)
+
+  **Regras de UI:**
+  - Cards de KPI usam `sx={{ bgcolor: 'primary.main', color: 'white' }}` para os números e ícone temático (ex: `AssignmentIcon`, `ScienceIcon`, `PeopleIcon`, `BatteryChargingFullIcon`)
+  - Nenhum campo de input nesta tela — é 100% leitura
+  - Responsivo: cards em `Grid size={{ xs: 12, sm: 6, md: 4 }}`, tabela em `Grid size={{ xs: 12 }}`
+  - Skeleton MUI durante loading dos KPIs
 
 ### Sabrina — `feat/sabrina/laudos`
 

--- a/backend/src/infrastructure/web/urls.py
+++ b/backend/src/infrastructure/web/urls.py
@@ -91,4 +91,17 @@ urlpatterns = [
         views.ClienteDetailView.as_view(),
         name="cliente_detail",
     ),
+    # ---------------------------------------------------------
+    # 6 DASHBOARD DO TÉCNICO
+    # ---------------------------------------------------------
+    path(
+        "dashboard/stats/",
+        views.DashboardStatsView.as_view(),
+        name="dashboard_stats",
+    ),
+    path(
+        "dashboard/laudos-recentes/",
+        views.DashboardLaudosRecentesView.as_view(),
+        name="dashboard_laudos_recentes",
+    ),
 ]

--- a/backend/src/infrastructure/web/views.py
+++ b/backend/src/infrastructure/web/views.py
@@ -529,3 +529,73 @@ class ClienteDetailView(generics.RetrieveUpdateDestroyAPIView):
         from rest_framework.permissions import IsAdminUser
 
         return [IsAuthenticated(), IsAdminUser()]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6 DASHBOARD DO TÉCNICO
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class DashboardStatsView(APIView):
+    """
+    GET /api/dashboard/stats/
+    Retorna KPIs agregados do laboratório. Somente staff.
+    """
+
+    def get_permissions(self):
+        from rest_framework.permissions import IsAdminUser
+
+        return [IsAuthenticated(), IsAdminUser()]
+
+    def get(self, request):
+        from django.utils import timezone
+        from django.db.models import Count
+
+        hoje = timezone.now().date()
+        primeiro_do_mes = hoje.replace(day=1)
+
+        stats = {
+            "total_laudos": Laudo.objects.count(),
+            "laudos_mes": Laudo.objects.filter(
+                data_emissao__gte=primeiro_do_mes
+            ).count(),
+            "total_amostras": AnaliseSolo.objects.count(),
+            "amostras_mes": AnaliseSolo.objects.filter(
+                data_entrada__gte=primeiro_do_mes
+            ).count(),
+            "total_clientes": Cliente.objects.count(),
+            "baterias_ativas": BateriaCalibracao.objects.filter(ativo=True).count(),
+        }
+        return Response(stats)
+
+
+class DashboardLaudosRecentesView(APIView):
+    """
+    GET /api/dashboard/laudos-recentes/
+    Retorna os 5 laudos criados mais recentemente. Somente staff.
+    """
+
+    def get_permissions(self):
+        from rest_framework.permissions import IsAdminUser
+
+        return [IsAuthenticated(), IsAdminUser()]
+
+    def get(self, request):
+        from django.db.models import Count
+
+        laudos = (
+            Laudo.objects.select_related("cliente")
+            .annotate(total_analises=Count("analises"))
+            .order_by("-id")[:5]
+        )
+        data = [
+            {
+                "id": l.id,
+                "codigo_laudo": l.codigo_laudo,
+                "cliente_nome": l.cliente.nome,
+                "data_emissao": l.data_emissao.isoformat(),
+                "total_analises": l.total_analises,
+            }
+            for l in laudos
+        ]
+        return Response(data)

--- a/labas-web/src/App.tsx
+++ b/labas-web/src/App.tsx
@@ -25,6 +25,7 @@ const LaudoDetalhePage = lazy(() => import("./pages/laudos/LaudoDetalhePage"));
 const LaudosPage = lazy(() => import("./pages/laudos/LaudosPage"));
 const ClientesPage = lazy(() => import("./pages/clientes/ClientesPage"));
 const ClienteFormPage = lazy(() => import("./pages/clientes/ClienteFormPage"));
+const GuidePage = lazy(() => import("./pages/dashboard/GuidePage"));
 
 const Spinner = () => (
   <Box display="flex" justifyContent="center" py={8}>
@@ -41,6 +42,16 @@ export default function App() {
 
       {/* Rotas protegidas — qualquer usuário autenticado */}
       <Route element={<PrivateRoute />}>
+        <Route
+          path="/guia"
+          element={
+            <AppShell>
+              <Suspense fallback={<Spinner />}>
+                <GuidePage />
+              </Suspense>
+            </AppShell>
+          }
+        />
         <Route
           path="/dashboard"
           element={

--- a/labas-web/src/components/layout/AppSidebar.tsx
+++ b/labas-web/src/components/layout/AppSidebar.tsx
@@ -13,6 +13,7 @@ import ScienceIcon from "@mui/icons-material/Science";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 import PeopleIcon from "@mui/icons-material/People";
 import BiotechIcon from "@mui/icons-material/Biotech";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
 import { NavLink } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
 
@@ -24,6 +25,7 @@ interface Props {
 const navComum = [
   { label: "Dashboard", icon: <DashboardIcon />, to: "/dashboard" },
   { label: "Meus Laudos", icon: <AssignmentIcon />, to: "/laudos" },
+  { label: "Guia de Uso", icon: <MenuBookIcon />, to: "/guia" },
 ];
 
 /** Itens de navegação exclusivos de staff */

--- a/labas-web/src/hooks/useDashboardLaudos.ts
+++ b/labas-web/src/hooks/useDashboardLaudos.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from "react";
+import { dashboardService } from "../services/dashboardService";
+import { useSnackbar } from "./useSnackbar";
+import type { LaudoResumo } from "../types/dashboard";
+
+export interface UseDashboardLaudosResult {
+  laudos: LaudoResumo[];
+  loading: boolean;
+  erro: string | null;
+  recarregar: () => void;
+}
+
+export function useDashboardLaudos(): UseDashboardLaudosResult {
+  const { showApiError } = useSnackbar();
+  const [laudos, setLaudos] = useState<LaudoResumo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+
+  const carregar = useCallback(async () => {
+    setLoading(true);
+    setErro(null);
+    try {
+      const data = await dashboardService.buscarLaudosRecentes();
+      setLaudos(data);
+    } catch (err) {
+      setErro("Não foi possível carregar os laudos recentes.");
+      showApiError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [showApiError]);
+
+  useEffect(() => {
+    void carregar();
+  }, [carregar]);
+
+  return { laudos, loading, erro, recarregar: carregar };
+}

--- a/labas-web/src/hooks/useDashboardStats.ts
+++ b/labas-web/src/hooks/useDashboardStats.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from "react";
+import { dashboardService } from "../services/dashboardService";
+import { useSnackbar } from "./useSnackbar";
+import type { DashboardStats } from "../types/dashboard";
+
+export interface UseDashboardStatsResult {
+  stats: DashboardStats | null;
+  loading: boolean;
+  erro: string | null;
+  recarregar: () => void;
+}
+
+export function useDashboardStats(): UseDashboardStatsResult {
+  const { showApiError } = useSnackbar();
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+
+  const carregar = useCallback(async () => {
+    setLoading(true);
+    setErro(null);
+    try {
+      const data = await dashboardService.buscarStats();
+      setStats(data);
+    } catch (err) {
+      setErro("Não foi possível carregar os indicadores.");
+      showApiError(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [showApiError]);
+
+  useEffect(() => {
+    void carregar();
+  }, [carregar]);
+
+  return { stats, loading, erro, recarregar: carregar };
+}

--- a/labas-web/src/pages/clientes/ClienteFormPage.tsx
+++ b/labas-web/src/pages/clientes/ClienteFormPage.tsx
@@ -52,12 +52,19 @@ export default function ClienteFormPage() {
   }
 
   return (
-    <Box>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        pt: 2,
+      }}
+    >
       <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
         {edicao ? "Editar Cliente" : "Novo Cliente"}
       </Typography>
 
-      <Paper variant="outlined" sx={{ p: 3, maxWidth: 600 }}>
+      <Paper variant="outlined" sx={{ p: 3, width: "100%", maxWidth: 560 }}>
         <Stack component="form" onSubmit={onSubmit} spacing={2}>
           <Controller
             name="codigo"

--- a/labas-web/src/pages/dashboard/DashboardPlaceholder.tsx
+++ b/labas-web/src/pages/dashboard/DashboardPlaceholder.tsx
@@ -1,79 +1,10 @@
-import {
-  Box,
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  CircularProgress,
-  Typography,
-} from "@mui/material";
-import { NavLink } from "react-router-dom";
+import { Box, CircularProgress, Typography } from "@mui/material";
 import { useAuth } from "../../hooks/useAuth";
 import { useLaudos } from "../../hooks/useLaudos";
 import ClientDashboard from "./components/ClientDashboard";
+import StaffDashboard from "./StaffDashboard";
 
-const staffCards = [
-  {
-    title: "Laudos",
-    description: "Criar e acompanhar laudos de análise.",
-    to: "/laudos/novo",
-  },
-  {
-    title: "Calibração",
-    description: "Gerenciar baterias e curvas de calibração.",
-    to: "/calibracao",
-  },
-  {
-    title: "Operação em Lote",
-    description: "Inserir leituras em lote na bancada.",
-    to: "/entrada-lote",
-  },
-];
-
-function StaffDashboard({ username }: { username: string }) {
-  return (
-    <Box>
-      <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
-        Olá, {username} 👋
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        Acesso rápido às rotinas do laboratório.
-      </Typography>
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" },
-          gap: 2,
-        }}
-      >
-        {staffCards.map((card) => (
-          <Card key={card.to} variant="outlined">
-            <CardContent>
-              <Typography variant="h6" fontWeight={700} gutterBottom>
-                {card.title}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                {card.description}
-              </Typography>
-            </CardContent>
-            <CardActions sx={{ px: 2, pb: 2 }}>
-              <Button
-                component={NavLink}
-                to={card.to}
-                variant="contained"
-                size="small"
-              >
-                Acessar
-              </Button>
-            </CardActions>
-          </Card>
-        ))}
-      </Box>
-    </Box>
-  );
-}
-
-function ClienteDashboardWrapper({ username }: { username: string }) {
+function ClienteDashboardWrapper() {
   const { laudos, loading, baixarPdf } = useLaudos();
 
   if (loading) {
@@ -84,23 +15,16 @@ function ClienteDashboardWrapper({ username }: { username: string }) {
     );
   }
 
-  return (
-    <Box>
-      <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
-        Olá, {username} 👋
-      </Typography>
-      <ClientDashboard laudos={laudos} onBaixarPdf={baixarPdf} />
-    </Box>
-  );
+  return <ClientDashboard laudos={laudos} onBaixarPdf={baixarPdf} />;
 }
 
 export default function DashboardPlaceholder() {
-  const { user, isStaff } = useAuth();
+  const { isStaff, user } = useAuth();
   const username = user?.username ?? "";
 
   return isStaff ? (
     <StaffDashboard username={username} />
   ) : (
-    <ClienteDashboardWrapper username={username} />
+    <ClienteDashboardWrapper />
   );
 }

--- a/labas-web/src/pages/dashboard/GuidePage.tsx
+++ b/labas-web/src/pages/dashboard/GuidePage.tsx
@@ -1,0 +1,230 @@
+import { useState } from "react";
+import {
+  Box,
+  Tab,
+  Tabs,
+  Typography,
+  Paper,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import CircleIcon from "@mui/icons-material/Circle";
+
+interface TabPanelProps {
+  children: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel({ children, index, value }: TabPanelProps) {
+  return (
+    <Box role="tabpanel" hidden={value !== index} sx={{ py: 3 }}>
+      {value === index && children}
+    </Box>
+  );
+}
+
+interface SecaoProps {
+  titulo: string;
+  descricao: string;
+  passos: string[];
+  dicas?: string[];
+}
+
+function SecaoGuia({ titulo, descricao, passos, dicas }: SecaoProps) {
+  return (
+    <Box>
+      <Typography variant="h6" fontWeight={700} gutterBottom>
+        {titulo}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {descricao}
+      </Typography>
+
+      <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1 }}>
+        Passo a passo:
+      </Typography>
+      <List dense disablePadding sx={{ mb: 2 }}>
+        {passos.map((passo, i) => (
+          <ListItem key={i} disableGutters>
+            <ListItemIcon sx={{ minWidth: 28 }}>
+              <CircleIcon sx={{ fontSize: 8, color: "primary.main" }} />
+            </ListItemIcon>
+            <ListItemText
+              primary={
+                <Typography variant="body2">
+                  <strong>{i + 1}.</strong> {passo}
+                </Typography>
+              }
+            />
+          </ListItem>
+        ))}
+      </List>
+
+      {dicas && dicas.length > 0 && (
+        <>
+          <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1 }}>
+            Dicas:
+          </Typography>
+          {dicas.map((dica, i) => (
+            <Box
+              key={i}
+              sx={{
+                bgcolor: "primary.main",
+                borderRadius: 1,
+                px: 2,
+                py: 1,
+                mb: 1,
+              }}
+            >
+              <Typography
+                variant="body2"
+                fontWeight={700}
+                sx={{ color: "white" }}
+              >
+                {dica}
+              </Typography>
+            </Box>
+          ))}
+        </>
+      )}
+    </Box>
+  );
+}
+
+const abas = [
+  "Visão Geral",
+  "Calibração",
+  "Entrada de Amostras",
+  "Laudos",
+  "Clientes",
+];
+
+const conteudo: SecaoProps[] = [
+  {
+    titulo: "Visão Geral do LABAS",
+    descricao:
+      "O LABAS é o sistema de gestão do laboratório de análise de solos e sementes. Centralize todo o fluxo desde o cadastro de clientes até a emissão do laudo final.",
+    passos: [
+      "Cadastre o cliente antes de qualquer coisa — sem cliente não é possível criar um laudo.",
+      "Calibre o equipamento correto e verifique se a bateria está ativa para o elemento desejado.",
+      "Crie o laudo e associe-o ao cliente cadastrado.",
+      "Acesse 'Amostras' e insira as leituras brutas em lote para as análises desse laudo.",
+      "Volte ao laudo e verifique quais amostras devem constar no PDF (ative/inative pelo toggle).",
+      "Gere o PDF com todas as análises ativas e entregue ao cliente.",
+    ],
+    dicas: [
+      "Fluxo correto: Cadastrar Cliente → Calibrar Equipamento (bateria ativa) → Criar Laudo → Inserir Amostras → Revisar Análises → Gerar PDF.",
+      "Apenas técnicos (staff) têm acesso completo. Clientes visualizam apenas seus laudos e fazem download do PDF.",
+      "Nunca insira amostras sem antes confirmar que a bateria está ativa para o elemento correspondente.",
+    ],
+  },
+  {
+    titulo: "Calibração de Equipamentos",
+    descricao:
+      "O módulo de calibração gerencia as baterias de calibração de cada equipamento (AA, FC, ES, pH). Uma bateria ativa é necessária para que os resultados das amostras sejam calculados corretamente.",
+    passos: [
+      "Acesse 'Calibração' na sidebar.",
+      "Clique em 'Nova Calibração' e selecione o equipamento e elemento.",
+      "Insira os pontos de calibração: concentração e leitura bruta do padrão.",
+      "O sistema calculará automaticamente a curva y = ax + b e o R².",
+      "Verifique que o R² está acima do mínimo aceitável e ative a bateria.",
+      "Somente uma bateria por elemento/equipamento pode estar ativa por vez.",
+    ],
+    dicas: [
+      "O branco deve ser inserido como ponto com concentração 0.",
+      "Se o R² estiver baixo, revise as leituras dos padrões antes de ativar.",
+    ],
+  },
+  {
+    titulo: "Entrada de Amostras (Operação em Lote)",
+    descricao:
+      "A tela de entrada de amostras permite inserir leituras brutas do equipamento em lote para um conjunto de análises. O sistema usa a bateria ativa do dia para calcular o resultado automaticamente.",
+    passos: [
+      "Acesse 'Amostras' na sidebar.",
+      "Selecione o elemento que será lido (ex: Ca, Mg, K).",
+      "Confirme a curva de calibração ativa exibida na tela.",
+      "Para cada amostra, informe o N_Lab, o Fator de Diluição e a Leitura Bruta.",
+      "Pressione Enter para avançar para a próxima linha — a leitura é salva em background.",
+      "O resultado calculado aparece automaticamente na coluna 'Resultado'.",
+    ],
+    dicas: [
+      "O N_Lab segue o padrão AAAA/NNN (ex: 2026/001).",
+      "Se uma leitura precisar ser corrigida, acesse o Laudo correspondente e use o ícone de correção na análise.",
+      "Certifique-se de que há uma bateria ativa para o elemento antes de inserir leituras.",
+    ],
+  },
+  {
+    titulo: "Laudos",
+    descricao:
+      "O módulo de laudos gerencia os documentos entregues aos clientes. Cada laudo pode conter até 50 análises de solo individuais. O PDF final é gerado com todas as análises ativas.",
+    passos: [
+      "Acesse 'Meus Laudos' na sidebar para ver a lista de laudos.",
+      "Clique em 'Novo Laudo' para criar um cabeçalho: selecione o cliente e a data de entrada.",
+      "Após criar o laudo, você será redirecionado para a tela de edição.",
+      "As análises são associadas ao laudo via 'Entrada de Amostras'.",
+      "Na tela de edição, você pode corrigir fichas, ajustar granulometria e inativar análises.",
+      "Quando o laudo estiver pronto, clique em 'Gerar PDF' para baixar o documento.",
+    ],
+    dicas: [
+      "O código do laudo (ex: L-2026/1) é gerado automaticamente — não é editável.",
+      "Análises inativas (toggle desligado) não aparecem no PDF.",
+      "Use o ícone de correção (tubo de ensaio) para ajustar leituras brutas sem precisar refazer toda a entrada.",
+    ],
+  },
+  {
+    titulo: "Clientes",
+    descricao:
+      "O módulo de clientes mantém o cadastro de produtores e empresas que enviam amostras ao laboratório.",
+    passos: [
+      "Acesse 'Clientes' na sidebar.",
+      "Clique em 'Novo Cliente' para cadastrar: nome, código, endereço e contato.",
+      "O código do cliente é usado para associá-lo a laudos — defina um padrão consistente (ex: iniciais + número).",
+      "Use a busca para localizar clientes rapidamente pelo nome ou código.",
+      "Clique em editar para atualizar os dados cadastrais a qualquer momento.",
+    ],
+    dicas: [
+      "O código do cliente não pode ser alterado após a criação.",
+      "Clientes inativos podem ter laudos associados — remova com cautela.",
+    ],
+  },
+];
+
+export default function GuidePage() {
+  const [aba, setAba] = useState(0);
+
+  return (
+    <Box>
+      <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
+        Guia de Uso do LABAS
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Consulte este guia para entender o fluxo de cada módulo do sistema.
+      </Typography>
+
+      <Paper variant="outlined">
+        <Tabs
+          value={aba}
+          onChange={(_, v: number) => setAba(v)}
+          variant="scrollable"
+          scrollButtons="auto"
+          sx={{ borderBottom: 1, borderColor: "divider", px: 2 }}
+        >
+          {abas.map((label) => (
+            <Tab key={label} label={label} />
+          ))}
+        </Tabs>
+
+        <Box sx={{ px: 3 }}>
+          {conteudo.map((secao, i) => (
+            <TabPanel key={i} value={aba} index={i}>
+              <SecaoGuia {...secao} />
+            </TabPanel>
+          ))}
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/labas-web/src/pages/dashboard/StaffDashboard.tsx
+++ b/labas-web/src/pages/dashboard/StaffDashboard.tsx
@@ -1,0 +1,249 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Paper,
+} from "@mui/material";
+import AssignmentIcon from "@mui/icons-material/Assignment";
+import ScienceIcon from "@mui/icons-material/Science";
+import PeopleIcon from "@mui/icons-material/People";
+import BatteryChargingFullIcon from "@mui/icons-material/BatteryChargingFull";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import BiotechIcon from "@mui/icons-material/Biotech";
+import { useNavigate } from "react-router-dom";
+import { NavLink } from "react-router-dom";
+import { useDashboardStats } from "../../hooks/useDashboardStats";
+import { useDashboardLaudos } from "../../hooks/useDashboardLaudos";
+
+interface KpiCardProps {
+  label: string;
+  value: number | undefined;
+  loading: boolean;
+  icon: React.ReactNode;
+}
+
+function KpiCard({ label, value, loading, icon }: KpiCardProps) {
+  return (
+    <Card
+      elevation={0}
+      sx={{
+        bgcolor: "primary.main",
+        color: "white",
+        border: "none",
+      }}
+    >
+      <CardContent sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+        <Box
+          sx={{
+            bgcolor: "rgba(255,255,255,0.15)",
+            borderRadius: 2,
+            p: 1.5,
+            display: "flex",
+            alignItems: "center",
+            color: "white",
+          }}
+        >
+          {icon}
+        </Box>
+        <Box>
+          <Typography
+            variant="caption"
+            sx={{ color: "rgba(255,255,255,0.75)", display: "block" }}
+          >
+            {label}
+          </Typography>
+          {loading ? (
+            <Skeleton
+              width={48}
+              height={32}
+              sx={{ bgcolor: "rgba(255,255,255,0.2)" }}
+            />
+          ) : (
+            <Typography variant="h5" fontWeight={700} sx={{ color: "white" }}>
+              {value ?? 0}
+            </Typography>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}
+
+const acoesRapidas = [
+  { label: "Novo Laudo", to: "/laudos/novo", variant: "contained" as const },
+  {
+    label: "Nova Calibração",
+    to: "/calibracao/nova",
+    variant: "outlined" as const,
+  },
+  {
+    label: "Entrada de Amostras",
+    to: "/entrada-lote",
+    variant: "outlined" as const,
+  },
+];
+
+export default function StaffDashboard({
+  username: _username,
+}: {
+  username: string;
+}) {
+  const navigate = useNavigate();
+  const { stats, loading: loadingStats } = useDashboardStats();
+  const { laudos, loading: loadingLaudos } = useDashboardLaudos();
+
+  const hoje = new Date().toLocaleDateString("pt-BR", {
+    weekday: "long",
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+
+  const kpis = [
+    {
+      label: "Laudos Totais",
+      value: stats?.total_laudos,
+      icon: <AssignmentIcon />,
+    },
+    {
+      label: "Laudos este Mês",
+      value: stats?.laudos_mes,
+      icon: <CalendarMonthIcon />,
+    },
+    {
+      label: "Amostras Totais",
+      value: stats?.total_amostras,
+      icon: <BiotechIcon />,
+    },
+    {
+      label: "Amostras este Mês",
+      value: stats?.amostras_mes,
+      icon: <ScienceIcon />,
+    },
+    {
+      label: "Clientes Cadastrados",
+      value: stats?.total_clientes,
+      icon: <PeopleIcon />,
+    },
+    {
+      label: "Baterias Ativas",
+      value: stats?.baterias_ativas,
+      icon: <BatteryChargingFullIcon />,
+    },
+  ];
+
+  return (
+    <Box>
+      <Typography variant="h5" fontWeight={700} color="primary" gutterBottom>
+        Painel do Laboratório
+      </Typography>
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ mb: 3, textTransform: "capitalize" }}
+      >
+        {hoje}
+      </Typography>
+
+      {/* KPIs */}
+      <Grid container spacing={2} sx={{ mb: 4 }}>
+        {kpis.map((kpi) => (
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={kpi.label}>
+            <KpiCard
+              label={kpi.label}
+              value={kpi.value}
+              loading={loadingStats}
+              icon={kpi.icon}
+            />
+          </Grid>
+        ))}
+      </Grid>
+
+      {/* Laudos recentes + Ações rápidas */}
+      <Grid container spacing={3}>
+        {/* Tabela de laudos recentes */}
+        <Grid size={{ xs: 12, md: 8 }}>
+          <Typography variant="h6" fontWeight={600} gutterBottom>
+            Laudos Recentes
+          </Typography>
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Código</TableCell>
+                  <TableCell>Cliente</TableCell>
+                  <TableCell>Data Entrada</TableCell>
+                  <TableCell align="right">Amostras</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {loadingLaudos
+                  ? Array.from({ length: 5 }).map((_, i) => (
+                      <TableRow key={i}>
+                        <TableCell>
+                          <Skeleton />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton />
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  : laudos.map((l) => (
+                      <TableRow
+                        key={l.id}
+                        hover
+                        onClick={() => navigate(`/laudos/${l.id}`)}
+                        sx={{ cursor: "pointer" }}
+                      >
+                        <TableCell>{l.codigo_laudo}</TableCell>
+                        <TableCell>{l.cliente_nome}</TableCell>
+                        <TableCell>
+                          {new Date(l.data_emissao).toLocaleDateString("pt-BR")}
+                        </TableCell>
+                        <TableCell align="right">{l.total_analises}</TableCell>
+                      </TableRow>
+                    ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+
+        {/* Ações rápidas */}
+        <Grid size={{ xs: 12, md: 4 }}>
+          <Typography variant="h6" fontWeight={600} gutterBottom>
+            Ações Rápidas
+          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            {acoesRapidas.map((acao) => (
+              <Button
+                key={acao.to}
+                component={NavLink}
+                to={acao.to}
+                variant={acao.variant}
+                fullWidth
+              >
+                {acao.label}
+              </Button>
+            ))}
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/labas-web/src/services/dashboardService.ts
+++ b/labas-web/src/services/dashboardService.ts
@@ -1,0 +1,16 @@
+import { api } from "./api";
+import type { DashboardStats, LaudoResumo } from "../types/dashboard";
+
+export const dashboardService = {
+  async buscarStats(): Promise<DashboardStats> {
+    const { data } = await api.get<DashboardStats>("/dashboard/stats/");
+    return data;
+  },
+
+  async buscarLaudosRecentes(): Promise<LaudoResumo[]> {
+    const { data } = await api.get<LaudoResumo[]>(
+      "/dashboard/laudos-recentes/",
+    );
+    return data;
+  },
+};

--- a/labas-web/src/types/dashboard.ts
+++ b/labas-web/src/types/dashboard.ts
@@ -1,0 +1,20 @@
+// ─── KPIs agregados do laboratório ───────────────────────────────────────────
+
+export interface DashboardStats {
+  total_laudos: number;
+  laudos_mes: number;
+  total_amostras: number;
+  amostras_mes: number;
+  total_clientes: number;
+  baterias_ativas: number;
+}
+
+// ─── Resumo de laudo para tabela de recentes ─────────────────────────────────
+
+export interface LaudoResumo {
+  id: number;
+  codigo_laudo: string;
+  cliente_nome: string;
+  data_emissao: string;
+  total_analises: number;
+}


### PR DESCRIPTION
## O que essa PR entrega

### Backend
- `GET /api/dashboard/stats/` — KPIs agregados (laudos, amostras, clientes, baterias ativas)
- `GET /api/dashboard/laudos-recentes/` — últimos 5 laudos

### Frontend
- `StaffDashboard` — 6 cards de KPI com Skeleton + tabela de laudos recentes + ações rápidas
- `GuidePage` — rota `/guia` com 5 abas (Visão Geral, Calibração, Amostras, Laudos, Clientes)
- Sidebar: item 'Guia de Uso' visível para todos os perfis
- Saudação 'Olá, nome' removida do dashboard — substituída por data do dia
- Formulário de cliente centralizado

## Fixes
- Erro 500: campo `ativa` → `ativo` no filtro de baterias
- Erro de nesting HTML (`<a>` > `<td>`): `TableRow component={NavLink}` trocado por `onClick + navigate`
- Contraste: cards KPI com fundo azul e texto branco