### PR TITLE
feat: delete de amostras, organização de grids, centralização calibração e README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,147 @@
-# LABAS-Software
+# LABAS — Sistema de Análise de Solo
 
-## Sobre o Projeto
+Sistema de gestão laboratorial desenvolvido como Projeto de Extensão em parceria com o curso de Agronomia da Universidade Federal de Uberlândia (UFU). O LABAS substitui o uso de planilhas manuais por uma plataforma digital integrada, cobrindo o ciclo completo: cadastro de amostras, calibração de equipamentos, cálculo agrônomico automatizado e geração de laudos técnicos em PDF.
 
-O LABAS é um sistema desenvolvido como Projeto de Extensão em parceria com o curso de Agronomia da Universidade Federal de Uberlândia (UFU).
+**Status:** Em desenvolvimento ativo
 
-O software foi concebido para modernizar, otimizar e automatizar as operações laboratoriais voltadas para o agronegócio. A aplicação substitui o uso de planilhas manuais, oferecendo uma infraestrutura digital robusta para o registo de amostras (nutrientes do solo e sementes), modelagem de dados e a geração automatizada de laudos técnicos.
+---
 
-**Estado do Projeto:** Em Produção
+## Indice
 
-## Estrutura do Sistema
+- [Visao Geral da Arquitetura](#visao-geral-da-arquitetura)
+- [Estrutura de Pastas](#estrutura-de-pastas)
+- [Equipe](#equipe)
+- [Documentacao Tecnica](#documentacao-tecnica)
+- [Como Executar](#como-executar)
+- [Boas Praticas Aplicadas](#boas-praticas-aplicadas)
+- [Fluxo de Branches](#fluxo-de-branches)
 
-A arquitetura do projeto está dividida em duas camadas principais, desenvolvidas e mantidas de forma independente para garantir escalabilidade:
+---
 
-- **Frontend:** Desenvolvido em React. Responsável por toda a interface de utilizador, apresentação de dados e consumo das APIs.
-- **Backend:** Desenvolvido em Python e Django, com base de dados PostgreSQL. Responsável pela lógica de negócio, arquitetura de software, processamento de dados e gestão da lógica laboratorial.
+## Visao Geral da Arquitetura
 
-## Equipa de Desenvolvimento
+O sistema e composto por duas aplicacoes independentes que se comunicam via API REST:
 
-O sistema é mantido por dois responsáveis técnicos, focados em áreas distintas da aplicação:
+| Camada   | Tecnologia                                             | Pasta        |
+| -------- | ------------------------------------------------------ | ------------ |
+| Backend  | Python 3.11 + Django 5.2 + Django REST Framework + JWT | `backend/`   |
+| Frontend | React 19 + TypeScript + Material UI v7 + Vite          | `labas-web/` |
 
-- **Desenvolvedor Frontend:** Ana Luiza Lamonier e Sabrina Ferreira Costa - Responsável pela interface web e experiência de utilização.
-- **Desenvolvedor Backend:** Gabriel Azevedo - Responsável pela arquitetura do servidor, desenvolvimento de APIs e modelagem da base de dados.
+A autenticacao e feita via JWT (SimpleJWT). O frontend consome a API em `http://localhost:8000/api/`. A geracao de laudos PDF utiliza WeasyPrint com templates HTML/CSS customizados.
 
-## Documentação Técnica
+---
 
-Para obter detalhes técnicos sobre a configuração do ambiente de desenvolvimento e guias de execução locais, consulte a documentação específica dentro de cada diretório:
+## Estrutura de Pastas
 
-- Documentação da Interface: `/frontend/README.md`
-- Documentação da API: `/backend/README.md`
+```
+LABAS-Software/
+  backend/                  — API Django REST Framework
+    config/                 — Configuracoes globais (settings, urls, wsgi)
+    src/
+      application/          — Regras de negocio puras (Use Cases, calculadoras)
+      infrastructure/
+        database/           — Models, migrations, signals
+        web/                — Serializers, Views, Permissions, URLs
+    static/css/             — Estilos dos laudos PDF
+    templates/laudos/       — Template HTML para WeasyPrint
+    test/                   — Testes automatizados por elemento quimico
+  labas-web/                — Interface React
+    src/
+      types/                — Interfaces TypeScript
+      services/             — Clientes Axios (uma responsabilidade por arquivo)
+      hooks/                — Custom Hooks (logica de estado e API)
+      schemas/              — Schemas de validacao Zod
+      pages/                — Paginas por modulo (auth, laudos, calibracao, etc.)
+      components/           — Componentes reutilizaveis (layout, shared)
+      contexts/             — Contextos globais (Auth, Snackbar)
+```
+
+---
+
+## Equipe
+
+| Funcao                  | Responsavel      |
+| ----------------------- | ---------------- |
+| Arquitetura e Backend   | Gabriel Azevedo  |
+| Arquitetura e Frontend  | Gabriel Azevedo  |
+| Infraestrutura e Deploy | Sabrina Ferreira |
+
+---
+
+## Documentacao Tecnica
+
+A documentacao detalhada de cada camada esta nos diretórios respectivos:
+
+- **Backend** — [`backend/README.md`](backend/README.md): stack, arquitetura Clean Architecture, rotas da API, contratos de dados, autenticacao JWT, permissoes, geracao de PDF e instrucoes de execucao local.
+- **Frontend** — [`labas-web/README.md`](labas-web/README.md): pre-requisitos, instalacao, variaveis de ambiente, estrutura de componentes e guia de desenvolvimento.
+
+A API tambem expoe documentacao interativa via OpenAPI 3 (drf-spectacular) quando o servidor Django esta em execucao:
+
+- Swagger UI: `http://localhost:8000/api/schema/swagger-ui/`
+- Redoc: `http://localhost:8000/api/schema/redoc/`
+
+---
+
+## Como Executar
+
+### Backend
+
+Requer Python 3.11+ e [Poetry](https://python-poetry.org/).
+
+```bash
+cd backend
+poetry install
+poetry run python manage.py migrate
+poetry run python manage.py createsuperuser
+poetry run python manage.py runserver
+```
+
+O servidor sobe em `http://localhost:8000`.
+
+### Frontend
+
+Requer Node.js 20+ e npm 10+.
+
+```bash
+cd labas-web
+npm install
+npm run dev
+```
+
+A interface sobe em `http://localhost:5173`.
+
+---
+
+## Boas Praticas Aplicadas
+
+### Backend
+
+- **Clean Architecture simplificada:** a camada `application/` contem os Use Cases e calculadoras de equipamentos sem nenhuma dependencia do Django, garantindo testabilidade isolada.
+- **Principio da Responsabilidade Unica:** cada calculadora de equipamento (`equipamentos/`) trata exclusivamente de um elemento quimico.
+- **Sinais Django (`signals`):** o recalculo de indices agronomicos (SB, CTC, V%, m%) e disparado automaticamente apos cada salvamento de `AnaliseSolo`, sem acoplamento entre a view e a logica de calculo.
+- **Serializadores com validacao de negocio:** o `AnaliseSoloSerializer` valida unicidade global de `n_lab` e retorna erros de campo no formato padrao DRF, compativel com o tratamento de erros do frontend.
+- **Permissoes granulares:** `IsAuthenticated` para leitura; `IsAdminUser` para operacoes de escrita. Clientes (`is_staff=False`) so acessam os proprios laudos via `IsOwnerOrStaff`.
+- **Sem logica de negocio em Views:** as views sao finas — delegam processamento para Use Cases e serializers.
+- **Testes por elemento:** cada elemento quimico possui um script de teste dedicado em `test/`, cobrindo o calculo da curva de calibracao e o resultado final.
+
+### Frontend
+
+- **Sem HTTP direto em componentes:** toda comunicacao com a API passa por `services/` e e orquestrada por Custom Hooks.
+- **Separacao de responsabilidades (SOLID):** `types/` para contratos, `services/` para HTTP, `hooks/` para estado e efeitos, `components/` para UI pura.
+- **Validacao com Zod + React Hook Form:** todos os formularios tem schema de validacao declarativo; erros de API (400) sao mapeados para campos do formulario.
+- **Feedback consistente:** loading states, Skeleton MUI durante carregamento de dados e Snackbar global para erros de API.
+- **Rotas protegidas:** `PrivateRoute` (autenticacao) e `StaffRoute` (permissao de staff) encapsulam o controle de acesso sem duplicar logica.
+- **Grid v2 do MUI:** uso padrao de `Grid` com `size={{ xs, sm, md }}` sem dependencias de modulos instáveis.
+- **Sem `any`:** tipagem TypeScript estrita em todo o projeto.
+
+---
+
+## Fluxo de Branches
+
+| Branch   | Finalidade                                        |
+| -------- | ------------------------------------------------- |
+| `main`   | Producao — apenas merges de `dev` via PR revisado |
+| `dev`    | Integracao — base para todas as features          |
+| `feat/*` | Features individuais — criadas a partir de `dev`  |
+
+Nenhum commit vai direto para `main` ou `dev`. Todo codigo passa por Pull Request com revisao obrigatoria.

--- a/backend/src/infrastructure/web/serializers.py
+++ b/backend/src/infrastructure/web/serializers.py
@@ -169,16 +169,22 @@ class AnaliseSoloSerializer(serializers.ModelSerializer):
     )
 
     def validate(self, data):
-        """Valida unicidade de n_lab no escopo do laudo pai."""
-        laudo = self.context.get("laudo")
+        """Valida unicidade global de n_lab — um n_lab só pode existir em um único laudo."""
         n_lab = data.get("n_lab", getattr(self.instance, "n_lab", None))
-        if laudo and n_lab:
-            qs = AnaliseSolo.objects.filter(laudo=laudo, n_lab=n_lab)
+        if n_lab:
+            qs = AnaliseSolo.objects.filter(n_lab=n_lab)
             if self.instance:
                 qs = qs.exclude(pk=self.instance.pk)
             if qs.exists():
+                existente = qs.select_related("laudo").first()
                 raise serializers.ValidationError(
-                    {"n_lab": "Já existe uma análise com este N Lab neste laudo."}
+                    {
+                        "n_lab": (
+                            f"N_Lab '{n_lab}' já está cadastrado no laudo "
+                            f"{existente.laudo.codigo_laudo}. "
+                            "Cada amostra só pode pertencer a um único laudo."
+                        )
+                    }
                 )
         return data
 

--- a/labas-web/src/pages/calibracao/CalibracaoFormPage.tsx
+++ b/labas-web/src/pages/calibracao/CalibracaoFormPage.tsx
@@ -134,120 +134,127 @@ export default function CalibracaoFormPage() {
 
       {/* ---- Step 1: Dados da Bateria ---- */}
       {activeStep === 0 && (
-        <Paper variant="outlined" sx={{ p: 3, maxWidth: 560 }}>
-          <Stack spacing={2} component="form" onSubmit={handleCriarBateria}>
-            <TextField
-              select
-              label="Equipamento"
-              {...bateriaForm.register("equipamento")}
-              error={!!bateriaForm.formState.errors.equipamento}
-              helperText={bateriaForm.formState.errors.equipamento?.message}
-              defaultValue={equipamentoInicial ?? "AA"}
-            >
-              {EQUIPAMENTOS.map((eq) => (
-                <MenuItem key={eq.value} value={eq.value}>
-                  {eq.label}
-                </MenuItem>
-              ))}
-            </TextField>
+        <Box display="flex" justifyContent="center">
+          <Paper variant="outlined" sx={{ p: 3, width: "100%", maxWidth: 560 }}>
+            <Stack spacing={2} component="form" onSubmit={handleCriarBateria}>
+              <TextField
+                select
+                label="Equipamento"
+                {...bateriaForm.register("equipamento")}
+                error={!!bateriaForm.formState.errors.equipamento}
+                helperText={bateriaForm.formState.errors.equipamento?.message}
+                defaultValue={equipamentoInicial ?? "AA"}
+              >
+                {EQUIPAMENTOS.map((eq) => (
+                  <MenuItem key={eq.value} value={eq.value}>
+                    {eq.label}
+                  </MenuItem>
+                ))}
+              </TextField>
 
-            <TextField
-              select
-              label="Elemento"
-              {...bateriaForm.register("elemento")}
-              error={!!bateriaForm.formState.errors.elemento}
-              helperText={bateriaForm.formState.errors.elemento?.message}
-              defaultValue=""
-            >
-              {elementosFiltrados.map((el) => (
-                <MenuItem key={el} value={el}>
-                  {ELEMENTO_LABEL[el]}
-                </MenuItem>
-              ))}
-            </TextField>
+              <TextField
+                select
+                label="Elemento"
+                {...bateriaForm.register("elemento")}
+                error={!!bateriaForm.formState.errors.elemento}
+                helperText={bateriaForm.formState.errors.elemento?.message}
+                defaultValue=""
+              >
+                {elementosFiltrados.map((el) => (
+                  <MenuItem key={el} value={el}>
+                    {ELEMENTO_LABEL[el]}
+                  </MenuItem>
+                ))}
+              </TextField>
 
-            {/* Campos condicionais */}
-            {REQUER_VOLUMES.includes(bateriaForm.watch("equipamento")) && (
-              <>
+              {/* Campos condicionais */}
+              {REQUER_VOLUMES.includes(bateriaForm.watch("equipamento")) && (
+                <>
+                  <TextField
+                    label="Volume de Solo (dm³)"
+                    type="text"
+                    inputProps={{
+                      inputMode: "decimal",
+                      pattern: "[0-9]*[.,]?[0-9]*",
+                    }}
+                    {...bateriaForm.register("volume_solo", {
+                      setValueAs: (value) =>
+                        normalizeDecimalOptional(String(value)),
+                    })}
+                    error={!!bateriaForm.formState.errors.volume_solo}
+                    helperText={
+                      bateriaForm.formState.errors.volume_solo?.message
+                    }
+                  />
+                  <TextField
+                    label="Volume de Extrator (mL)"
+                    type="text"
+                    inputProps={{
+                      inputMode: "decimal",
+                      pattern: "[0-9]*[.,]?[0-9]*",
+                    }}
+                    {...bateriaForm.register("volume_extrator", {
+                      setValueAs: (value) =>
+                        normalizeDecimalOptional(String(value)),
+                    })}
+                    error={!!bateriaForm.formState.errors.volume_extrator}
+                    helperText={
+                      bateriaForm.formState.errors.volume_extrator?.message
+                    }
+                  />
+                </>
+              )}
+
+              {REQUER_BRANCO.includes(bateriaForm.watch("equipamento")) && (
                 <TextField
-                  label="Volume de Solo (dm³)"
+                  label="Leitura do Branco"
                   type="text"
                   inputProps={{
                     inputMode: "decimal",
                     pattern: "[0-9]*[.,]?[0-9]*",
                   }}
-                  {...bateriaForm.register("volume_solo", {
+                  {...bateriaForm.register("leitura_branco", {
                     setValueAs: (value) =>
                       normalizeDecimalOptional(String(value)),
                   })}
-                  error={!!bateriaForm.formState.errors.volume_solo}
-                  helperText={bateriaForm.formState.errors.volume_solo?.message}
-                />
-                <TextField
-                  label="Volume de Extrator (mL)"
-                  type="text"
-                  inputProps={{
-                    inputMode: "decimal",
-                    pattern: "[0-9]*[.,]?[0-9]*",
-                  }}
-                  {...bateriaForm.register("volume_extrator", {
-                    setValueAs: (value) =>
-                      normalizeDecimalOptional(String(value)),
-                  })}
-                  error={!!bateriaForm.formState.errors.volume_extrator}
+                  error={!!bateriaForm.formState.errors.leitura_branco}
                   helperText={
-                    bateriaForm.formState.errors.volume_extrator?.message
+                    bateriaForm.formState.errors.leitura_branco?.message
                   }
                 />
-              </>
-            )}
+              )}
 
-            {REQUER_BRANCO.includes(bateriaForm.watch("equipamento")) && (
-              <TextField
-                label="Leitura do Branco"
-                type="text"
-                inputProps={{
-                  inputMode: "decimal",
-                  pattern: "[0-9]*[.,]?[0-9]*",
-                }}
-                {...bateriaForm.register("leitura_branco", {
-                  setValueAs: (value) =>
-                    normalizeDecimalOptional(String(value)),
-                })}
-                error={!!bateriaForm.formState.errors.leitura_branco}
-                helperText={
-                  bateriaForm.formState.errors.leitura_branco?.message
+              <FormControlLabel
+                control={
+                  <Switch defaultChecked {...bateriaForm.register("ativo")} />
                 }
+                label="Marcar como bateria ativa"
               />
-            )}
 
-            <FormControlLabel
-              control={
-                <Switch defaultChecked {...bateriaForm.register("ativo")} />
-              }
-              label="Marcar como bateria ativa"
-            />
-
-            <Button
-              type="submit"
-              variant="contained"
-              disabled={submittingBateria}
-              startIcon={
-                submittingBateria ? <CircularProgress size={16} /> : null
-              }
-            >
-              {submittingBateria ? "Criando..." : "Criar Bateria"}
-            </Button>
-          </Stack>
-        </Paper>
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={submittingBateria}
+                startIcon={
+                  submittingBateria ? <CircularProgress size={16} /> : null
+                }
+              >
+                {submittingBateria ? "Criando..." : "Criar Bateria"}
+              </Button>
+            </Stack>
+          </Paper>
+        </Box>
       )}
 
       {/* ---- Step 2: Pontos de Calibração ---- */}
       {activeStep === 1 && (
-        <Box>
+        <Box display="flex" justifyContent="center">
           {/* Titulação / pH-metro: sem curva de calibração */}
           {SEM_CURVA_CALIBRACAO.includes(equipamento) ? (
-            <Paper variant="outlined" sx={{ p: 3, maxWidth: 560 }}>
+            <Paper
+              variant="outlined"
+              sx={{ p: 3, width: "100%", maxWidth: 560 }}
+            >
               <Typography variant="body1" mb={2}>
                 Este equipamento não utiliza curva de calibração.
               </Typography>
@@ -260,9 +267,9 @@ export default function CalibracaoFormPage() {
               </Button>
             </Paper>
           ) : (
-            <Box>
+            <Box sx={{ width: "100%", maxWidth: 560 }}>
               {isEdicao && bateria && (
-                <Paper variant="outlined" sx={{ p: 3, mb: 3, maxWidth: 560 }}>
+                <Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
                   <Typography variant="subtitle2" mb={2}>
                     Parametros da bateria
                   </Typography>
@@ -408,7 +415,7 @@ export default function CalibracaoFormPage() {
                   </Typography>
                   <Table
                     size="small"
-                    sx={{ mb: 2, maxWidth: 560 }}
+                    sx={{ mb: 2 }}
                     aria-label="Pontos cadastrados"
                   >
                     <TableHead>
@@ -449,11 +456,7 @@ export default function CalibracaoFormPage() {
               <Typography variant="subtitle2" mb={1}>
                 Adicionar novos pontos
               </Typography>
-              <Table
-                size="small"
-                sx={{ mb: 1, maxWidth: 560 }}
-                aria-label="Novos pontos"
-              >
+              <Table size="small" sx={{ mb: 1 }} aria-label="Novos pontos">
                 <TableHead>
                   <TableRow>
                     <TableCell>Concentração (padrão)</TableCell>

--- a/labas-web/src/pages/dashboard/components/ClientDashboard.tsx
+++ b/labas-web/src/pages/dashboard/components/ClientDashboard.tsx
@@ -9,11 +9,11 @@ import {
   Typography,
 } from "@mui/material";
 import StatusChip from "../../../components/shared/StatusChip";
-import type { AnaliseSolo } from "../../../types/analise";
+import type { Laudo } from "../../../types/analise";
 
 interface Props {
-  laudos: AnaliseSolo[];
-  onBaixarPdf: (nLab: string) => void;
+  laudos: Laudo[];
+  onBaixarPdf: (id: number, codigoLaudo: string) => void;
 }
 
 const formatarData = (value: string) => {
@@ -24,8 +24,8 @@ const formatarData = (value: string) => {
   return data.toLocaleDateString("pt-BR");
 };
 
-const ordenarPorEntrada = (a: AnaliseSolo, b: AnaliseSolo) =>
-  new Date(b.data_entrada).getTime() - new Date(a.data_entrada).getTime();
+const ordenarPorEntrada = (a: Laudo, b: Laudo) =>
+  new Date(b.data_emissao).getTime() - new Date(a.data_emissao).getTime();
 
 export default function ClientDashboard({ laudos, onBaixarPdf }: Props) {
   const recentes = [...laudos].sort(ordenarPorEntrada).slice(0, 5);
@@ -53,14 +53,14 @@ export default function ClientDashboard({ laudos, onBaixarPdf }: Props) {
 
               return (
                 <ListItem
-                  key={laudo.n_lab}
+                  key={laudo.id}
                   divider
                   sx={{ px: 0, alignItems: "flex-start" }}
                   secondaryAction={
                     <Button
                       size="small"
                       variant="outlined"
-                      onClick={() => onBaixarPdf(laudo.n_lab)}
+                      onClick={() => onBaixarPdf(laudo.id, laudo.codigo_laudo)}
                     >
                       Baixar PDF
                     </Button>
@@ -77,12 +77,12 @@ export default function ClientDashboard({ laudos, onBaixarPdf }: Props) {
                         }}
                       >
                         <Typography variant="subtitle2" fontWeight={700}>
-                          {laudo.n_lab}
+                          {laudo.codigo_laudo}
                         </Typography>
                         <StatusChip status={status} />
                       </Box>
                     }
-                    secondary={`Entrada: ${formatarData(laudo.data_entrada)}`}
+                    secondary={`Entrada: ${formatarData(laudo.data_emissao)}`}
                   />
                 </ListItem>
               );

--- a/labas-web/src/pages/laudos/LaudoDetalhePage.tsx
+++ b/labas-web/src/pages/laudos/LaudoDetalhePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Box,
@@ -7,6 +7,7 @@ import {
   CircularProgress,
   Divider,
   Grid,
+  IconButton,
   Paper,
   Stack,
   Tooltip,
@@ -14,74 +15,17 @@ import {
 } from "@mui/material";
 import DownloadIcon from "@mui/icons-material/Download";
 import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { DataGrid, type GridColDef } from "@mui/x-data-grid";
 import PageHeader from "../../components/shared/PageHeader";
 import LoadingOverlay from "../../components/shared/LoadingOverlay";
+import ConfirmDialog from "../../components/shared/ConfirmDialog";
 import { laudoService } from "../../services/laudoService";
 import { useAnalises } from "../../hooks/useAnalises";
 import { useSnackbar } from "../../hooks/useSnackbar";
 import { useAuth } from "../../hooks/useAuth";
 import type { Laudo, AnaliseSolo } from "../../types/analise";
-
-// ─── Colunas do DataGrid (somente leitura) ───────────────────────────────────
-
-const colunas: GridColDef<AnaliseSolo>[] = [
-  { field: "n_lab", headerName: "N° Lab", width: 110 },
-  {
-    field: "referencia",
-    headerName: "Referência",
-    width: 150,
-    valueGetter: (_val, row) => row.referencia ?? "—",
-  },
-  { field: "data_entrada", headerName: "Data Entrada", width: 120 },
-  {
-    field: "ativo",
-    headerName: "Status",
-    width: 100,
-    renderCell: ({ value }) =>
-      value ? (
-        <Chip label="Ativa" color="success" size="small" />
-      ) : (
-        <Chip label="Inativa" size="small" />
-      ),
-  },
-  {
-    field: "sb",
-    headerName: "SB",
-    width: 90,
-    type: "number",
-    valueGetter: (_val, row) => row.sb ?? "—",
-  },
-  {
-    field: "T_maiusculo",
-    headerName: "CTC",
-    width: 90,
-    type: "number",
-    valueGetter: (_val, row) => row.T_maiusculo ?? "—",
-  },
-  {
-    field: "V",
-    headerName: "V%",
-    width: 80,
-    type: "number",
-    valueGetter: (_val, row) => row.V ?? "—",
-  },
-  {
-    field: "m",
-    headerName: "m%",
-    width: 80,
-    type: "number",
-    valueGetter: (_val, row) => row.m ?? "—",
-  },
-  {
-    field: "ph_agua",
-    headerName: "pH (água)",
-    width: 100,
-    type: "number",
-    valueGetter: (_val, row) => row.ph_agua ?? "—",
-  },
-];
 
 // ─── Componente ──────────────────────────────────────────────────────────────
 
@@ -97,7 +41,16 @@ export default function LaudoDetalhePage() {
   const [erroFetch, setErroFetch] = useState(false);
   const [baixando, setBaixando] = useState(false);
 
-  const { analises, loading: analisesLoading } = useAnalises(laudoId);
+  const {
+    analises,
+    loading: analisesLoading,
+    remover,
+    removendo,
+  } = useAnalises(laudoId);
+
+  const [confirmarRemocao, setConfirmarRemocao] = useState<AnaliseSolo | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!laudoId || isNaN(laudoId)) {
@@ -114,6 +67,92 @@ export default function LaudoDetalhePage() {
       })
       .finally(() => setBuscando(false));
   }, [laudoId, showApiError]);
+
+  const colunas = useMemo(
+    (): GridColDef<AnaliseSolo>[] => [
+      ...(isStaff
+        ? [
+            {
+              field: "acoes",
+              headerName: "",
+              width: 56,
+              minWidth: 56,
+              sortable: false,
+              renderCell: ({ row }: { row: AnaliseSolo }) => (
+                <Tooltip title="Remover análise">
+                  <span>
+                    <IconButton
+                      size="small"
+                      color="error"
+                      disabled={removendo === row.id}
+                      onClick={() => setConfirmarRemocao(row)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              ),
+            } satisfies GridColDef<AnaliseSolo>,
+          ]
+        : []),
+      { field: "n_lab", headerName: "N° Lab", width: 110 },
+      {
+        field: "referencia",
+        headerName: "Referência",
+        flex: 1,
+        minWidth: 120,
+        valueGetter: (_val, row) => row.referencia ?? "—",
+      },
+      { field: "data_entrada", headerName: "Data Entrada", width: 120 },
+      {
+        field: "ativo",
+        headerName: "Status",
+        width: 100,
+        renderCell: ({ value }) =>
+          value ? (
+            <Chip label="Ativa" color="success" size="small" />
+          ) : (
+            <Chip label="Inativa" size="small" />
+          ),
+      },
+      {
+        field: "sb",
+        headerName: "SB",
+        width: 80,
+        type: "number",
+        valueGetter: (_val, row) => row.sb ?? "—",
+      },
+      {
+        field: "T_maiusculo",
+        headerName: "CTC",
+        width: 80,
+        type: "number",
+        valueGetter: (_val, row) => row.T_maiusculo ?? "—",
+      },
+      {
+        field: "V",
+        headerName: "V%",
+        width: 75,
+        type: "number",
+        valueGetter: (_val, row) => row.V ?? "—",
+      },
+      {
+        field: "m",
+        headerName: "m%",
+        width: 75,
+        type: "number",
+        valueGetter: (_val, row) => row.m ?? "—",
+      },
+      {
+        field: "ph_agua",
+        headerName: "pH (água)",
+        width: 95,
+        type: "number",
+        valueGetter: (_val, row) => row.ph_agua ?? "—",
+      },
+    ],
+    [isStaff, removendo],
+  );
 
   const handleBaixarPdf = async () => {
     if (!laudo) return;
@@ -264,6 +303,18 @@ export default function LaudoDetalhePage() {
           </Button>
         )}
       </Stack>
+
+      <ConfirmDialog
+        open={!!confirmarRemocao}
+        title="Remover análise"
+        message={`Deseja remover permanentemente a análise ${confirmarRemocao?.n_lab}? Esta ação não pode ser desfeita.`}
+        confirmLabel="Remover"
+        onClose={() => setConfirmarRemocao(null)}
+        onConfirm={async () => {
+          if (confirmarRemocao) await remover(confirmarRemocao.id);
+          setConfirmarRemocao(null);
+        }}
+      />
     </Box>
   );
 }

--- a/labas-web/src/pages/laudos/LaudoEditPage.tsx
+++ b/labas-web/src/pages/laudos/LaudoEditPage.tsx
@@ -191,44 +191,11 @@ export default function LaudoEditPage() {
   };
 
   const colunas: GridColDef<AnaliseSolo>[] = [
-    { field: "n_lab", headerName: "N° Lab", width: 110 },
-    { field: "referencia", headerName: "Referência", flex: 1 },
-    { field: "data_entrada", headerName: "Entrada", width: 110 },
-    {
-      field: "ativo",
-      headerName: "Ativo",
-      width: 90,
-      renderCell: ({ row }) => (
-        <Chip
-          size="small"
-          label={row.ativo ? "Sim" : "Não"}
-          color={row.ativo ? "success" : "default"}
-        />
-      ),
-    },
-    {
-      field: "sb",
-      headerName: "SB",
-      width: 80,
-      valueFormatter: (value: number | null) => value ?? "—",
-    },
-    {
-      field: "ctc",
-      headerName: "CTC",
-      width: 80,
-      valueFormatter: (value: number | null) => value ?? "—",
-    },
-    {
-      field: "v",
-      headerName: "V%",
-      width: 80,
-      valueFormatter: (value: number | null) =>
-        value != null ? `${value}%` : "—",
-    },
     {
       field: "acoes",
       headerName: "Ações",
-      width: 100,
+      width: 140,
+      minWidth: 140,
       sortable: false,
       renderCell: ({ row }) => (
         <Stack direction="row" spacing={0.5}>
@@ -274,6 +241,40 @@ export default function LaudoEditPage() {
           </Tooltip>
         </Stack>
       ),
+    },
+    { field: "n_lab", headerName: "N° Lab", width: 110 },
+    { field: "referencia", headerName: "Referência", flex: 1, minWidth: 120 },
+    { field: "data_entrada", headerName: "Entrada", width: 110 },
+    {
+      field: "ativo",
+      headerName: "Ativo",
+      width: 90,
+      renderCell: ({ row }) => (
+        <Chip
+          size="small"
+          label={row.ativo ? "Sim" : "Não"}
+          color={row.ativo ? "success" : "default"}
+        />
+      ),
+    },
+    {
+      field: "sb",
+      headerName: "SB",
+      width: 80,
+      valueFormatter: (value: number | null) => value ?? "—",
+    },
+    {
+      field: "ctc",
+      headerName: "CTC",
+      width: 80,
+      valueFormatter: (value: number | null) => value ?? "—",
+    },
+    {
+      field: "v",
+      headerName: "V%",
+      width: 80,
+      valueFormatter: (value: number | null) =>
+        value != null ? `${value}%` : "—",
     },
   ];
 


### PR DESCRIPTION
## Funcionalidades
- `LaudoDetalhePage`: botão de delete de análises para staff (lixeira na primeira coluna)
- `LaudoDetalhePage` e `LaudoEditPage`: coluna de ações movida para o início do grid
- `LaudoEditPage`: largura da coluna de ações corrigida de 100→140px
- `CalibracaoFormPage` Step 2: centralizado com maxWidth 560px

## Documentação
- `README.md` reescrito de forma profissional

## Fixes
- Unicidade global de n_lab no serializer
- Coluna Referência com flex: 1